### PR TITLE
Migrate TemplateResponse to Starlette 1.0 API

### DIFF
--- a/api/core.py
+++ b/api/core.py
@@ -246,9 +246,6 @@ def register_template_filters(jinja_templates) -> None:
     """Register custom Jinja2 filters and globals on a Templates instance."""
     jinja_templates.env.filters["slugify"] = slugify
     jinja_templates.env.globals["app_version"] = get_app_version()
-    # Disable template caching to avoid Jinja2 >=3.1.5 unhashable cache key bug
-    # when env.globals are set. Performance impact is negligible for this app.
-    jinja_templates.env.cache = None
 
 
 # ---------------------------------------------------------------------------

--- a/api/main.py
+++ b/api/main.py
@@ -108,9 +108,9 @@ async def dashboard(
     ssh_host = urlparse(settings.BASE_URL).hostname or "localhost"
 
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
-        {
-            "request": request,
+        context={
             "user": user,
             "active_users": active_users,
             "active_hosts": active_hosts,
@@ -140,8 +140,9 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     accept = request.headers.get("accept", "")
     if "text/html" in accept:
         return templates.TemplateResponse(
+            request,
             "500.html",
-            {"request": request, "error": exc.detail},
+            context={"error": exc.detail},
             status_code=exc.status_code,
         )
     # API/JSON clients get the default JSON response
@@ -152,13 +153,13 @@ async def http_exception_handler(request: Request, exc: HTTPException):
 @app.exception_handler(500)
 async def internal_error_handler(request: Request, exc: Exception):
     logger.exception("Unhandled exception")
-    return templates.TemplateResponse("500.html", {"request": request}, status_code=500)
+    return templates.TemplateResponse(request, "500.html", status_code=500)
 
 
 @app.exception_handler(Exception)
 async def generic_exception_handler(request: Request, exc: Exception):
     logger.exception("Unhandled exception")
-    return templates.TemplateResponse("500.html", {"request": request}, status_code=500)
+    return templates.TemplateResponse(request, "500.html", status_code=500)
 
 
 # ---------------------------------------------------------------------------

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -75,7 +75,6 @@ async def audit_log(
     all_users = users_result.scalars().all()
 
     context = {
-        "request": request,
         "entries": entries,
         "user": user,
         "page": page,
@@ -90,6 +89,6 @@ async def audit_log(
     }
 
     if request.headers.get("HX-Request"):
-        return templates.TemplateResponse("partials/audit_rows.html", context)
+        return templates.TemplateResponse(request, "partials/audit_rows.html", context=context)
 
-    return templates.TemplateResponse("audit.html", context)
+    return templates.TemplateResponse(request, "audit.html", context=context)

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -40,7 +40,7 @@ async def login_page(request: Request):
     user = getattr(request.state, "user", None)
     if user and user.totp_enrolled:
         return RedirectResponse(url="/dashboard", status_code=303)
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse(request, "login.html")
 
 
 @router.post("/login")
@@ -71,8 +71,9 @@ async def login_submit(
             detail={"username": username, "reason": "user_not_found"},
         )
         return templates.TemplateResponse(
+            request,
             "login.html",
-            {"request": request, "error": error_msg},
+            context={"error": error_msg},
             status_code=401,
         )
 
@@ -87,8 +88,9 @@ async def login_submit(
             detail={"reason": "wrong_password", "target_username": user.username},
         )
         return templates.TemplateResponse(
+            request,
             "login.html",
-            {"request": request, "error": error_msg},
+            context={"error": error_msg},
             status_code=401,
         )
 
@@ -108,8 +110,9 @@ async def login_submit(
                 detail={"reason": "invalid_totp", "target_username": user.username},
             )
             return templates.TemplateResponse(
+                request,
                 "login.html",
-                {"request": request, "error": error_msg},
+                context={"error": error_msg},
                 status_code=401,
             )
 
@@ -167,9 +170,9 @@ async def totp_setup_page(
     qr_b64 = base64.b64encode(buf.getvalue()).decode()
 
     return templates.TemplateResponse(
+        request,
         "totp_setup.html",
-        {
-            "request": request,
+        context={
             "user": user,
             "qr_code": qr_b64,
             "totp_secret": secret,
@@ -204,9 +207,9 @@ async def totp_verify(
         qr_b64 = base64.b64encode(buf.getvalue()).decode()
 
         return templates.TemplateResponse(
+            request,
             "totp_setup.html",
-            {
-                "request": request,
+            context={
                 "user": user,
                 "qr_code": qr_b64,
                 "totp_secret": secret,

--- a/api/routers/hosts.py
+++ b/api/routers/hosts.py
@@ -42,8 +42,9 @@ async def host_list(
         all_users = users_result.scalars().all()
 
     return templates.TemplateResponse(
+        request,
         "hosts.html",
-        {"request": request, "hosts": hosts, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
+        context={"hosts": hosts, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
     )
 
 
@@ -69,8 +70,9 @@ async def create_host(
             ur = await db.execute(select(User).where(User.is_active == True).order_by(User.username))
             au = ur.scalars().all()
         return templates.TemplateResponse(
+            request,
             "hosts.html",
-            {"request": request, "error": detail, "hosts": all_hosts, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": au},
+            context={"error": detail, "hosts": all_hosts, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": au},
             status_code=400,
         )
 
@@ -153,8 +155,9 @@ async def deactivate_host(
         settings = get_settings()
         ssh_host = urlparse(settings.BASE_URL).hostname or "localhost"
         return templates.TemplateResponse(
+            request,
             "partials/host_row.html",
-            {"request": request, "host": host, "user": user, "settings": settings, "ssh_host": ssh_host},
+            context={"host": host, "user": user, "settings": settings, "ssh_host": ssh_host},
         )
     return RedirectResponse(url="/hosts", status_code=303)
 
@@ -233,8 +236,9 @@ async def assign_host(
         users_result = await db.execute(select(User).where(User.is_active == True).order_by(User.username))
         all_users = users_result.scalars().all()
         return templates.TemplateResponse(
+            request,
             "partials/host_row.html",
-            {"request": request, "host": host, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
+            context={"host": host, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
         )
     return RedirectResponse(url="/hosts", status_code=303)
 
@@ -282,7 +286,8 @@ async def unassign_host(
         users_result = await db.execute(select(User).where(User.is_active == True).order_by(User.username))
         all_users = users_result.scalars().all()
         return templates.TemplateResponse(
+            request,
             "partials/host_row.html",
-            {"request": request, "host": host, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
+            context={"host": host, "user": user, "settings": settings, "ssh_host": ssh_host, "all_users": all_users},
         )
     return RedirectResponse(url="/hosts", status_code=303)

--- a/api/routers/setup.py
+++ b/api/routers/setup.py
@@ -78,7 +78,7 @@ async def _is_fully_setup() -> bool:
 async def setup_page(request: Request):
     if not await _is_setup_needed():
         raise HTTPException(status_code=404)
-    return templates.TemplateResponse("setup.html", {"request": request})
+    return templates.TemplateResponse(request, "setup.html")
 
 
 @router.post("/setup")
@@ -108,8 +108,9 @@ async def setup_submit(
 
     if errors:
         return templates.TemplateResponse(
+            request,
             "setup.html",
-            {"request": request, "error": " ".join(errors), "username": username, "display_name": display_name},
+            context={"error": " ".join(errors), "username": username, "display_name": display_name},
             status_code=400,
         )
 
@@ -125,8 +126,9 @@ async def setup_submit(
             existing = await db.execute(select(User).where(User.username == username))
             if existing.scalar_one_or_none():
                 return templates.TemplateResponse(
+                    request,
                     "setup.html",
-                    {"request": request, "error": f"Username '{username}' is already taken.", "username": username, "display_name": display_name},
+                    context={"error": f"Username '{username}' is already taken.", "username": username, "display_name": display_name},
                     status_code=400,
                 )
 
@@ -169,8 +171,9 @@ async def setup_submit(
             except IntegrityError:
                 await db.rollback()
                 return templates.TemplateResponse(
+                    request,
                     "setup.html",
-                    {"request": request, "error": f"Username '{username}' is already taken.", "username": username, "display_name": display_name},
+                    context={"error": f"Username '{username}' is already taken.", "username": username, "display_name": display_name},
                     status_code=400,
                 )
 
@@ -209,8 +212,9 @@ async def setup_totp_page(request: Request, user: User = Depends(get_current_use
     qr_b64 = base64.b64encode(buf.getvalue()).decode()
 
     return templates.TemplateResponse(
+        request,
         "setup_totp.html",
-        {"request": request, "user": user, "qr_code": qr_b64, "totp_secret": secret},
+        context={"user": user, "qr_code": qr_b64, "totp_secret": secret},
     )
 
 
@@ -240,8 +244,9 @@ async def setup_totp_verify(
         img.save(buf, format="PNG")
         qr_b64 = base64.b64encode(buf.getvalue()).decode()
         return templates.TemplateResponse(
+            request,
             "setup_totp.html",
-            {"request": request, "user": user, "qr_code": qr_b64, "totp_secret": secret, "error": "Invalid code. Please try again."},
+            context={"user": user, "qr_code": qr_b64, "totp_secret": secret, "error": "Invalid code. Please try again."},
             status_code=400,
         )
 

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -41,13 +41,15 @@ async def user_list(
 
     if request.headers.get("HX-Request"):
         return templates.TemplateResponse(
+            request,
             "users.html",
-            {"request": request, "users": users, "key_counts": key_counts, "user": user},
+            context={"users": users, "key_counts": key_counts, "user": user},
         )
 
     return templates.TemplateResponse(
+        request,
         "users.html",
-        {"request": request, "users": users, "key_counts": key_counts, "user": user},
+        context={"users": users, "key_counts": key_counts, "user": user},
     )
 
 
@@ -74,9 +76,9 @@ async def user_detail(
     ssh_host = urlparse(settings.BASE_URL).hostname or "localhost"
 
     return templates.TemplateResponse(
+        request,
         "user_detail.html",
-        {
-            "request": request,
+        context={
             "target_user": target_user,
             "keys": active_keys,
             "assigned_hosts": assigned_hosts,
@@ -112,8 +114,9 @@ async def create_user(
             for uid, count in cr.all():
                 kc[uid] = count
         return templates.TemplateResponse(
+            request,
             "users.html",
-            {"request": request, "error": detail, "users": all_users, "key_counts": kc, "user": user},
+            context={"error": detail, "users": all_users, "key_counts": kc, "user": user},
             status_code=400,
         )
 
@@ -193,8 +196,9 @@ async def deactivate_user(
         )
         key_count = key_count_result.scalar()
         return templates.TemplateResponse(
+            request,
             "partials/user_row.html",
-            {"request": request, "row_user": target, "key_count": key_count, "user": user},
+            context={"row_user": target, "key_count": key_count, "user": user},
         )
     return RedirectResponse(url="/users", status_code=303)
 
@@ -228,8 +232,9 @@ async def activate_user(
         )
         key_count = key_count_result.scalar()
         return templates.TemplateResponse(
+            request,
             "partials/user_row.html",
-            {"request": request, "row_user": target, "key_count": key_count, "user": user},
+            context={"row_user": target, "key_count": key_count, "user": user},
         )
     return RedirectResponse(url="/users", status_code=303)
 
@@ -342,8 +347,9 @@ async def upload_key(
         )
         keys = result.scalars().all()
         return templates.TemplateResponse(
+            request,
             "partials/key_list.html",
-            {"request": request, "keys": keys, "target_user_id": user_id, "user": user},
+            context={"keys": keys, "target_user_id": user_id, "user": user},
         )
     return RedirectResponse(url=f"/users/{user_id}", status_code=303)
 
@@ -380,7 +386,8 @@ async def revoke_key(
         )
         keys = keys_result.scalars().all()
         return templates.TemplateResponse(
+            request,
             "partials/key_list.html",
-            {"request": request, "keys": keys, "target_user_id": user_id, "user": user},
+            context={"keys": keys, "target_user_id": user_id, "user": user},
         )
     return RedirectResponse(url=f"/users/{user_id}", status_code=303)


### PR DESCRIPTION
## Summary
- Update all `TemplateResponse` calls to Starlette 1.0 positional arg order: `(request, name)` instead of `(name, context)`
- Remove Jinja2 `cache=None` workaround that was masking the same root cause
- Fixes all page loads broken by Starlette 1.0 + Jinja2 3.1.6 combination

## Context
Starlette 1.0.0 changed `TemplateResponse` from `(name, context_dict)` to `(request, name)`. The old API caused the context dict to be passed as the template name, resulting in `AttributeError: 'dict' object has no attribute 'split'` (with cache disabled) or `TypeError: unhashable type: 'dict'` (with cache enabled).

## Test plan
- [ ] `docker compose up --build` starts cleanly
- [ ] `/setup` page loads without error
- [ ] Login, user management, host management, and audit pages all render
- [ ] Error pages (404, 500) render correctly

