### PR TITLE
Add 2FA recovery codes, live SSH session visibility, and host groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Callis is a self-hosted SSH jump server (bastion host) with a web UI. It provide
 - Hardened OpenSSH jump server (Ed25519 host key; Ed25519 or RSA 4096+ user keys; no passwords, no interactive shell)
 - Server-rendered web UI (SvelteKit SSR) backed by a FastAPI JSON API — works without JavaScript, no CDN dependencies
 - Per-user OS accounts with instant key revocation
-- Mandatory TOTP 2FA for all web UI users
+- Mandatory TOTP 2FA for all web UI users, with single-use recovery codes for lost devices
 - Role-based access control (admin, operator, readonly)
+- Host groups — grant access to sets of hosts as a unit
+- Live SSH session view with admin session termination
 - Full audit log of every connection attempt and admin action
 - Fail2ban sidecar for SSH brute force protection
 - Rate limiting on web UI login

--- a/api/core.py
+++ b/api/core.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import hmac
 import io
 import logging
 import os
@@ -16,7 +17,7 @@ from urllib.parse import urlparse
 
 import pyotp
 import qrcode
-from sqlalchemy import select
+from sqlalchemy import delete, func, select, update
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
@@ -36,7 +37,16 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from models import AuditAction, AuditLog, Setting
+from models import (
+    AuditAction,
+    AuditLog,
+    Host,
+    RecoveryCode,
+    Setting,
+    host_group_hosts,
+    host_group_users,
+    user_host_assignment,
+)
 
 logger = logging.getLogger("callis")
 
@@ -431,6 +441,102 @@ def get_totp_uri(secret: str, username: str) -> str:
     return pyotp.TOTP(secret).provisioning_uri(name=username, issuer_name="Callis")
 
 
+# ---------------------------------------------------------------------------
+# 2FA recovery codes
+# ---------------------------------------------------------------------------
+
+RECOVERY_CODE_COUNT = 10
+# Unambiguous lowercase alphabet (no 0/o/1/l/i): 10 chars ≈ 49 bits of entropy.
+_RECOVERY_CODE_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
+_RECOVERY_CODE_LENGTH = 10
+
+
+def generate_recovery_code() -> str:
+    """Generate one recovery code, formatted as xxxxx-xxxxx."""
+    raw = "".join(secrets.choice(_RECOVERY_CODE_ALPHABET) for _ in range(_RECOVERY_CODE_LENGTH))
+    return f"{raw[:5]}-{raw[5:]}"
+
+
+def normalize_recovery_code(code: str) -> str:
+    """Normalize user input: lowercase, strip whitespace and hyphens."""
+    return code.strip().lower().replace("-", "").replace(" ", "")
+
+
+def hash_recovery_code(code: str) -> str:
+    """HMAC-SHA256 digest of a normalized recovery code, keyed by SECRET_KEY.
+
+    Recovery codes are high-entropy random strings (~49 bits), so a fast
+    keyed hash is appropriate — offline brute force is infeasible without
+    the server key, and the digest column can be indexed for O(1) lookup.
+    Passwords must NOT use this; they use bcrypt.
+    """
+    secret_key = get_settings().SECRET_KEY
+    return hmac.new(
+        secret_key.encode(),
+        f"callis-recovery:{normalize_recovery_code(code)}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def looks_like_recovery_code(code: str) -> bool:
+    """True if the submitted 2FA value has recovery-code shape (vs 6-digit TOTP).
+
+    Length alone distinguishes the formats: recovery codes normalize to 10
+    characters, TOTP codes are 6 digits. All-digit inputs of length 10 must
+    still qualify — the generation alphabet contains digits, so an issued
+    code can (rarely) be entirely numeric.
+    """
+    return len(normalize_recovery_code(code)) == _RECOVERY_CODE_LENGTH
+
+
+async def issue_recovery_codes(db: AsyncSession, user_id: str) -> list[str]:
+    """Replace all of a user's recovery codes with a fresh set.
+
+    Returns the plaintext codes — the only time they are ever available.
+    Does not commit; the caller owns the transaction.
+    """
+    await db.execute(delete(RecoveryCode).where(RecoveryCode.user_id == user_id))
+    codes = [generate_recovery_code() for _ in range(RECOVERY_CODE_COUNT)]
+    for code in codes:
+        db.add(RecoveryCode(user_id=user_id, code_digest=hash_recovery_code(code)))
+    await db.flush()
+    return codes
+
+
+async def consume_recovery_code(db: AsyncSession, user_id: str, submitted: str) -> bool:
+    """Mark a matching unused recovery code as used. Returns True on success.
+
+    Single-use is enforced atomically: the conditional UPDATE re-evaluates
+    ``used_at IS NULL`` at commit visibility, so two concurrent logins with
+    the same code cannot both succeed on PostgreSQL (SQLite is single-writer
+    and safe either way).
+
+    Does not commit; the caller owns the transaction.
+    """
+    digest = hash_recovery_code(submitted)
+    result = await db.execute(
+        update(RecoveryCode)
+        .where(
+            RecoveryCode.user_id == user_id,
+            RecoveryCode.code_digest == digest,
+            RecoveryCode.used_at.is_(None),
+        )
+        .values(used_at=datetime.now(timezone.utc))
+    )
+    return result.rowcount == 1
+
+
+async def unused_recovery_code_count(db: AsyncSession, user_id: str) -> int:
+    result = await db.execute(
+        select(func.count())
+        .select_from(RecoveryCode)
+        .where(RecoveryCode.user_id == user_id, RecoveryCode.used_at.is_(None))
+    )
+    return result.scalar()
+
+
+
+
 def totp_qr_b64(secret: str, username: str) -> str:
     """Render the TOTP provisioning URI as a base64-encoded PNG QR code."""
     uri = get_totp_uri(secret, username)
@@ -758,6 +864,39 @@ def get_server_deploy_public_key() -> str:
         logger.info("Generated Callis server deploy key and saved to %s", priv_path)
         _deploy_public_key_cache = public_key_text
         return public_key_text
+
+
+# ---------------------------------------------------------------------------
+# Effective host access (direct assignments ∪ group memberships)
+# ---------------------------------------------------------------------------
+
+async def get_effective_hosts(db: AsyncSession, user_id: str) -> list[Host]:
+    """Active hosts a user may reach: direct assignments plus host groups.
+
+    This is the single source of truth for host access — used by the
+    internal API (permitopen construction, tag resolution, and host
+    listing) and the web UI, so they can never disagree.
+    """
+    direct_ids = select(user_host_assignment.c.host_id).where(
+        user_host_assignment.c.user_id == user_id
+    )
+    group_ids = (
+        select(host_group_hosts.c.host_id)
+        .join(
+            host_group_users,
+            host_group_users.c.group_id == host_group_hosts.c.group_id,
+        )
+        .where(host_group_users.c.user_id == user_id)
+    )
+    result = await db.execute(
+        select(Host)
+        .where(
+            Host.is_active == True,  # noqa: E712
+            Host.id.in_(direct_ids.union(group_ids)),
+        )
+        .order_by(Host.label)
+    )
+    return result.scalars().all()
 
 
 # ---------------------------------------------------------------------------

--- a/api/main.py
+++ b/api/main.py
@@ -9,16 +9,17 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Response
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from sqlalchemy import select, func
+from sqlalchemy import select, func, text
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from core import get_engine, get_runtime_setting, get_session_factory, get_settings, limiter, load_db_settings
 from middleware import SecurityHeadersMiddleware, SessionMiddleware, TOTPGuardMiddleware
 from middleware.setup_guard import SetupGuardMiddleware
-from models import Base, User
-from routers import auth, users, hosts, audit, setup, settings as settings_router
+from models import AuditAction, Base, User
+from routers import auth, users, hosts, groups, sessions, audit, setup, settings as settings_router
 from routers import dashboard, meta
 from routers.internal import internal_app
+from session_tracker import close_stale_open_sessions, follow_sshd_log
 
 logger = logging.getLogger("callis")
 
@@ -51,7 +52,19 @@ async def lifespan(app: FastAPI):
             logger.warning("account is created. Do not expose this port until done.")
             logger.warning("=" * 60)
 
+    # SSH session tracking: close records orphaned by a previous run (unless
+    # their connection is still established), then follow the sshd log for
+    # live connect/disconnect events.
+    await close_stale_open_sessions()
+    tracker_task = asyncio.create_task(follow_sshd_log())
+
     yield
+
+    tracker_task.cancel()
+    try:
+        await tracker_task
+    except asyncio.CancelledError:
+        pass
     engine = get_engine()
     await engine.dispose()
 
@@ -100,6 +113,8 @@ app.include_router(auth.router, prefix=API_V1_PREFIX)
 app.include_router(setup.router, prefix=API_V1_PREFIX)
 app.include_router(users.router, prefix=API_V1_PREFIX)
 app.include_router(hosts.router, prefix=API_V1_PREFIX)
+app.include_router(groups.router, prefix=API_V1_PREFIX)
+app.include_router(sessions.router, prefix=API_V1_PREFIX)
 app.include_router(audit.router, prefix=API_V1_PREFIX)
 app.include_router(settings_router.router, prefix=API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=API_V1_PREFIX)
@@ -205,6 +220,28 @@ async def generic_exception_handler(request: Request, exc: Exception):
 _initialized: set[str] = set()
 
 
+async def _sync_pg_audit_enum(engine) -> None:
+    """PostgreSQL only: add any missing AuditAction labels to the native enum.
+
+    Base.metadata.create_all() creates missing tables but never alters an
+    existing native enum type, so an upgraded installation would fail on the
+    first write of a newly introduced audit action. ALTER TYPE ... ADD VALUE
+    cannot run inside a transaction block, hence the AUTOCOMMIT connection.
+    No-op for SQLite.
+    """
+    if engine.dialect.name != "postgresql":
+        return
+    async with engine.connect() as conn:
+        autocommit = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        for action in AuditAction:
+            # SQLAlchemy persists PEP-435 enum member NAMES (e.g.
+            # RECOVERY_CODE_USED), not .value — the labels added here must
+            # match. Names are our own identifiers (ASCII), safe to inline.
+            await autocommit.execute(
+                text(f"ALTER TYPE auditaction ADD VALUE IF NOT EXISTS '{action.name}'")
+            )
+
+
 async def _init_db():
     """Run DB initialization (table creation) — idempotent; no-op if already done."""
     if "db" in _initialized:
@@ -217,6 +254,7 @@ async def _init_db():
     engine = get_engine()
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    await _sync_pg_audit_enum(engine)
     _initialized.add("db")
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import shlex
 from contextlib import asynccontextmanager
@@ -61,10 +62,10 @@ async def lifespan(app: FastAPI):
     yield
 
     tracker_task.cancel()
-    try:
+    # Cancellation is the expected way the follower stops; anything else
+    # already logged inside the task.
+    with contextlib.suppress(asyncio.CancelledError):
         await tracker_task
-    except asyncio.CancelledError:
-        pass
     engine = get_engine()
     await engine.dispose()
 

--- a/api/models.py
+++ b/api/models.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     Column,
     DateTime,
@@ -41,6 +42,11 @@ class AuditAction(str, enum.Enum):
     LOGOUT = "logout"
     TOTP_SETUP = "totp_setup"
     TOTP_FAILURE = "totp_failure"
+    RECOVERY_CODE_USED = "recovery_code_used"
+    RECOVERY_CODES_GENERATED = "recovery_codes_generated"
+    SESSION_OPENED = "session_opened"
+    SESSION_CLOSED = "session_closed"
+    SESSION_TERMINATED = "session_terminated"
     KEY_ADDED = "key_added"
     KEY_REVOKED = "key_revoked"
     KEY_USED = "key_used"
@@ -54,6 +60,12 @@ class AuditAction(str, enum.Enum):
     HOST_DELETED = "host_deleted"
     HOST_ASSIGNED = "host_assigned"
     HOST_UNASSIGNED = "host_unassigned"
+    GROUP_CREATED = "group_created"
+    GROUP_DELETED = "group_deleted"
+    GROUP_HOST_ADDED = "group_host_added"
+    GROUP_HOST_REMOVED = "group_host_removed"
+    GROUP_USER_ADDED = "group_user_added"
+    GROUP_USER_REMOVED = "group_user_removed"
     SETTINGS_CHANGED = "settings_changed"
 
 
@@ -63,6 +75,40 @@ user_host_assignment = Table(
     Column("user_id", String(36), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
     Column("host_id", String(36), ForeignKey("hosts.id", ondelete="CASCADE"), primary_key=True),
 )
+
+host_group_hosts = Table(
+    "host_group_hosts",
+    Base.metadata,
+    Column("group_id", String(36), ForeignKey("host_groups.id", ondelete="CASCADE"), primary_key=True),
+    Column("host_id", String(36), ForeignKey("hosts.id", ondelete="CASCADE"), primary_key=True),
+)
+
+host_group_users = Table(
+    "host_group_users",
+    Base.metadata,
+    Column("group_id", String(36), ForeignKey("host_groups.id", ondelete="CASCADE"), primary_key=True),
+    Column("user_id", String(36), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class HostGroup(Base):
+    """A named set of hosts assignable to users as a unit.
+
+    A user's effective host access is the union of their direct host
+    assignments and the hosts of every group they belong to (see
+    core.get_effective_hosts — the single source of truth used by the
+    internal API for permitopen enforcement, resolve, and list).
+    """
+
+    __tablename__ = "host_groups"
+
+    id = Column(String(36), primary_key=True, default=_new_uuid)
+    name = Column(String(255), unique=True, nullable=False)
+    description = Column(Text, nullable=True, default="")
+    created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
+
+    hosts = relationship("Host", secondary=host_group_hosts, back_populates="groups")
+    users = relationship("User", secondary=host_group_users, back_populates="host_groups")
 
 
 class User(Base):
@@ -82,6 +128,8 @@ class User(Base):
 
     ssh_keys = relationship("SSHKey", back_populates="user", cascade="all, delete-orphan")
     assigned_hosts = relationship("Host", secondary=user_host_assignment, back_populates="assigned_users")
+    recovery_codes = relationship("RecoveryCode", back_populates="user", cascade="all, delete-orphan")
+    host_groups = relationship("HostGroup", secondary=host_group_users, back_populates="users")
 
 
 class SSHKey(Base):
@@ -100,6 +148,26 @@ class SSHKey(Base):
     user = relationship("User", back_populates="ssh_keys")
 
 
+class RecoveryCode(Base):
+    """Single-use 2FA recovery code.
+
+    Codes are stored as HMAC-SHA256 digests keyed by SECRET_KEY (see
+    core.hash_recovery_code) — codes are high-entropy random strings, so a
+    fast keyed hash is appropriate and allows indexed lookup, unlike
+    passwords which need bcrypt.
+    """
+
+    __tablename__ = "recovery_codes"
+
+    id = Column(String(36), primary_key=True, default=_new_uuid)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    code_digest = Column(String(64), nullable=False, index=True)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
+
+    user = relationship("User", back_populates="recovery_codes")
+
+
 class Host(Base):
     __tablename__ = "hosts"
 
@@ -112,6 +180,48 @@ class Host(Base):
     created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
 
     assigned_users = relationship("User", secondary=user_host_assignment, back_populates="assigned_hosts")
+    groups = relationship("HostGroup", secondary=host_group_hosts, back_populates="hosts")
+
+
+class SshSession(Base):
+    """An SSH connection through the bastion, tracked from the sshd log.
+
+    Rows are created/closed by session_tracker as sshd logs authentication
+    accepts and disconnects. username is stored denormalized so the record
+    survives user deletion (user_id is SET NULL).
+    """
+
+    __tablename__ = "ssh_sessions"
+
+    id = Column(String(36), primary_key=True, default=_new_uuid)
+    user_id = Column(String(36), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+    username = Column(String(255), nullable=False, index=True)
+    source_ip = Column(String(45), nullable=False)
+    source_port = Column(Integer, nullable=False)
+    key_fingerprint = Column(String(255), nullable=True)
+    started_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False, index=True)
+    ended_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    close_reason = Column(String(50), nullable=True)  # disconnected | terminated | server_restart
+
+    user = relationship("User", foreign_keys=[user_id])
+
+
+class SessionTrackerState(Base):
+    """Single-row bookkeeping for the sshd log follower.
+
+    Stores the last fully processed log position so an API restart resumes
+    where it stopped and reconciles sessions accepted while the API was
+    down (sshd keeps running under supervisord during api restarts).
+    """
+
+    __tablename__ = "session_tracker_state"
+
+    # BigInteger: inodes and file offsets are 64-bit values; PostgreSQL's
+    # Integer is signed 32-bit and would overflow on large logs/inodes.
+    id = Column(Integer, primary_key=True, default=1)
+    log_inode = Column(BigInteger, nullable=True)
+    log_offset = Column(BigInteger, nullable=True)
+    updated_at = Column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
 
 
 class AuditLog(Base):

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core import (
+    consume_recovery_code,
     create_jwt,
     decrypt_totp_secret,
     encrypt_totp_secret,
@@ -12,15 +13,18 @@ from core import (
     get_db,
     get_settings,
     hash_password,
+    issue_recovery_codes,
     limiter,
+    looks_like_recovery_code,
     totp_qr_b64,
+    unused_recovery_code_count,
     verify_password,
     verify_totp,
     write_audit_log,
 )
 from dependencies import get_current_user
 from models import AuditAction, User
-from schemas import LoginIn, SessionOut, TOTPSetupOut, TOTPVerifyIn, user_out
+from schemas import EnrollOut, LoginIn, SessionOut, TOTPSetupOut, TOTPVerifyIn, user_out
 
 router = APIRouter(prefix="/auth")
 
@@ -93,7 +97,27 @@ async def login_submit(
         secret = decrypt_totp_secret(user.totp_secret)
         submitted_totp_code = (body.totp_code or "").strip()
         # verify_totp already handles invalid/empty formats in constant-time
-        if not verify_totp(secret, submitted_totp_code):
+        totp_valid = verify_totp(secret, submitted_totp_code)
+
+        # A single-use recovery code may be entered in place of the TOTP code
+        # (lost/replaced authenticator device). Only attempted when the input
+        # has recovery-code shape, so 6-digit TOTP attempts never hit the DB.
+        used_recovery_code = False
+        if not totp_valid and looks_like_recovery_code(submitted_totp_code):
+            used_recovery_code = await consume_recovery_code(db, user.id, submitted_totp_code)
+
+        if used_recovery_code:
+            remaining = await unused_recovery_code_count(db, user.id)
+            await write_audit_log(
+                db,
+                actor_id=user.id,
+                action=AuditAction.RECOVERY_CODE_USED,
+                target_type="user",
+                target_id=user.id,
+                source_ip=request.client.host if request.client else None,
+                detail={"target_username": user.username, "remaining_codes": remaining},
+            )
+        elif not totp_valid:
             totp_failure_reason = "totp_missing" if not submitted_totp_code else "totp_invalid"
             await write_audit_log(
                 db,
@@ -153,7 +177,7 @@ async def totp_verify(
     body: TOTPVerifyIn,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> SessionOut:
+) -> EnrollOut:
     if user.totp_enrolled:
         raise HTTPException(status_code=409, detail="totp_already_enrolled")
 
@@ -178,7 +202,19 @@ async def totp_verify(
         source_ip=request.client.host if request.client else None,
     )
 
-    return SessionOut(user=user_out(db_user))
+    # Issue single-use recovery codes, returned exactly once.
+    codes = await issue_recovery_codes(db, db_user.id)
+    await write_audit_log(
+        db,
+        actor_id=db_user.id,
+        action=AuditAction.RECOVERY_CODES_GENERATED,
+        target_type="user",
+        target_id=db_user.id,
+        source_ip=request.client.host if request.client else None,
+        detail={"count": len(codes), "source": "totp_enrollment"},
+    )
+
+    return EnrollOut(user=user_out(db_user), recovery_codes=codes)
 
 
 @router.post("/logout")

--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import selectinload
 
 from core import get_db, get_settings, get_ssh_host
 from dependencies import require_totp_complete
-from models import AuditLog, Host, SSHKey, User
+from models import AuditLog, Host, SSHKey, SshSession, User
 from schemas import DashboardOut, audit_entry_out
 
 router = APIRouter()
@@ -36,6 +36,11 @@ async def dashboard(
     )
     user_key_count = key_count_result.scalar()
 
+    active_sessions_result = await db.execute(
+        select(func.count()).select_from(SshSession).where(SshSession.ended_at.is_(None))
+    )
+    active_sessions = active_sessions_result.scalar()
+
     # Recent audit (last 10)
     audit_result = await db.execute(
         select(AuditLog)
@@ -48,6 +53,7 @@ async def dashboard(
     return DashboardOut(
         active_users=active_users,
         active_hosts=active_hosts,
+        active_sessions=active_sessions,
         user_key_count=user_key_count,
         recent_audit=[audit_entry_out(e) for e in recent_audit],
         ssh_host=await get_ssh_host(),

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -1,0 +1,230 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from core import get_db, write_audit_log
+from dependencies import require_role, require_totp_complete
+from models import AuditAction, Host, HostGroup, User
+from schemas import CreateGroupIn, GroupOut, group_out
+
+router = APIRouter(prefix="/groups")
+
+_GROUP_NAME_MAX_LEN = 100
+
+
+def _validate_group_name(name: str) -> str:
+    name = name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Group name must not be empty")
+    if any(ord(c) < 32 or ord(c) == 127 for c in name):
+        raise HTTPException(status_code=400, detail="Group name must not contain control characters")
+    if len(name) > _GROUP_NAME_MAX_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Group name must not exceed {_GROUP_NAME_MAX_LEN} characters",
+        )
+    return name
+
+
+async def _group_or_404(db: AsyncSession, group_id: str) -> HostGroup:
+    result = await db.execute(
+        select(HostGroup)
+        .options(selectinload(HostGroup.hosts), selectinload(HostGroup.users))
+        .where(HostGroup.id == group_id)
+    )
+    group = result.scalar_one_or_none()
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return group
+
+
+@router.get("")
+async def group_list(
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_totp_complete),
+) -> list[GroupOut]:
+    result = await db.execute(
+        select(HostGroup)
+        .options(selectinload(HostGroup.hosts), selectinload(HostGroup.users))
+        .order_by(HostGroup.name)
+    )
+    return [group_out(g) for g in result.scalars().all()]
+
+
+@router.post("", status_code=201)
+async def create_group(
+    request: Request,
+    body: CreateGroupIn,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> GroupOut:
+    name = _validate_group_name(body.name)
+
+    existing = await db.execute(select(HostGroup).where(HostGroup.name == name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=400, detail="A group with this name already exists")
+
+    group = HostGroup(name=name, description=body.description)
+    db.add(group)
+    await db.flush()
+
+    await write_audit_log(
+        db,
+        actor_id=user.id,
+        action=AuditAction.GROUP_CREATED,
+        target_type="group",
+        target_id=group.id,
+        source_ip=request.client.host if request.client else None,
+        detail={"name": name},
+    )
+
+    return group_out(await _group_or_404(db, group.id))
+
+
+@router.delete("/{group_id}", status_code=204)
+async def delete_group(
+    request: Request,
+    group_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+):
+    group = await _group_or_404(db, group_id)
+
+    name = group.name
+    await db.delete(group)
+
+    await write_audit_log(
+        db,
+        actor_id=user.id,
+        action=AuditAction.GROUP_DELETED,
+        target_type="group",
+        target_id=group_id,
+        source_ip=request.client.host if request.client else None,
+        detail={"name": name},
+    )
+    return Response(status_code=204)
+
+
+@router.post("/{group_id}/hosts/{host_id}")
+async def add_host_to_group(
+    request: Request,
+    group_id: str,
+    host_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> GroupOut:
+    group = await _group_or_404(db, group_id)
+
+    host_result = await db.execute(select(Host).where(Host.id == host_id))
+    host = host_result.scalar_one_or_none()
+    if not host:
+        raise HTTPException(status_code=404, detail="Host not found")
+
+    if host not in group.hosts:
+        group.hosts.append(host)
+        await write_audit_log(
+            db,
+            actor_id=user.id,
+            action=AuditAction.GROUP_HOST_ADDED,
+            target_type="group",
+            target_id=group_id,
+            source_ip=request.client.host if request.client else None,
+            detail={"group_name": group.name, "host_label": host.label},
+        )
+
+    await db.flush()
+    return group_out(group)
+
+
+@router.delete("/{group_id}/hosts/{host_id}")
+async def remove_host_from_group(
+    request: Request,
+    group_id: str,
+    host_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> GroupOut:
+    group = await _group_or_404(db, group_id)
+
+    host_result = await db.execute(select(Host).where(Host.id == host_id))
+    host = host_result.scalar_one_or_none()
+    if not host:
+        raise HTTPException(status_code=404, detail="Host not found")
+
+    if host in group.hosts:
+        group.hosts.remove(host)
+        await write_audit_log(
+            db,
+            actor_id=user.id,
+            action=AuditAction.GROUP_HOST_REMOVED,
+            target_type="group",
+            target_id=group_id,
+            source_ip=request.client.host if request.client else None,
+            detail={"group_name": group.name, "host_label": host.label},
+        )
+
+    await db.flush()
+    return group_out(group)
+
+
+@router.post("/{group_id}/users/{target_user_id}")
+async def add_user_to_group(
+    request: Request,
+    group_id: str,
+    target_user_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> GroupOut:
+    group = await _group_or_404(db, group_id)
+
+    target_result = await db.execute(select(User).where(User.id == target_user_id))
+    target_user = target_result.scalar_one_or_none()
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if target_user not in group.users:
+        group.users.append(target_user)
+        await write_audit_log(
+            db,
+            actor_id=user.id,
+            action=AuditAction.GROUP_USER_ADDED,
+            target_type="group",
+            target_id=group_id,
+            source_ip=request.client.host if request.client else None,
+            detail={"group_name": group.name, "username": target_user.username},
+        )
+
+    await db.flush()
+    return group_out(group)
+
+
+@router.delete("/{group_id}/users/{target_user_id}")
+async def remove_user_from_group(
+    request: Request,
+    group_id: str,
+    target_user_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> GroupOut:
+    group = await _group_or_404(db, group_id)
+
+    target_result = await db.execute(select(User).where(User.id == target_user_id))
+    target_user = target_result.scalar_one_or_none()
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if target_user in group.users:
+        group.users.remove(target_user)
+        await write_audit_log(
+            db,
+            actor_id=user.id,
+            action=AuditAction.GROUP_USER_REMOVED,
+            target_type="group",
+            target_id=group_id,
+            source_ip=request.client.host if request.client else None,
+            detail={"group_name": group.name, "username": target_user.username},
+        )
+
+    await db.flush()
+    return group_out(group)

--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -9,8 +9,8 @@ from fastapi.responses import PlainTextResponse
 from sqlalchemy import select
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from core import get_session_factory, get_settings, slugify, write_audit_log
-from models import AuditAction, AuditLog, Host, SSHKey, User, user_host_assignment
+from core import get_effective_hosts, get_session_factory, get_settings, slugify, write_audit_log
+from models import AuditAction, AuditLog, SSHKey, User
 
 logger = logging.getLogger("callis")
 
@@ -164,16 +164,8 @@ async def get_keys(username: str, fp: str = Query("")):
         if not keys:
             return PlainTextResponse("", status_code=200)
 
-        # Get user's assigned hosts for permitopen enforcement
-        hosts_result = await db.execute(
-            select(Host)
-            .join(user_host_assignment)
-            .where(
-                user_host_assignment.c.user_id == user.id,
-                Host.is_active == True,
-            )
-        )
-        assigned_hosts = hosts_result.scalars().all()
+        # Effective hosts (direct + group assignments) for permitopen enforcement
+        assigned_hosts = await get_effective_hosts(db, user.id)
 
         # Build permitopen options from assigned hosts
         if assigned_hosts:
@@ -204,16 +196,8 @@ async def resolve_host(username: str, tag: str):
         if not user:
             return PlainTextResponse("", status_code=200)
 
-        # Get user's assigned active hosts
-        hosts_result = await db.execute(
-            select(Host)
-            .join(user_host_assignment)
-            .where(
-                user_host_assignment.c.user_id == user.id,
-                Host.is_active == True,
-            )
-        )
-        assigned_hosts = hosts_result.scalars().all()
+        # Effective hosts (direct + group assignments)
+        assigned_hosts = await get_effective_hosts(db, user.id)
 
         # Find all hosts whose slugified label matches the tag
         matching_hosts = [
@@ -242,16 +226,8 @@ async def list_hosts(username: str):
         if not user:
             return PlainTextResponse("", status_code=200)
 
-        # Get user's assigned active hosts
-        hosts_result = await db.execute(
-            select(Host)
-            .join(user_host_assignment)
-            .where(
-                user_host_assignment.c.user_id == user.id,
-                Host.is_active == True,
-            )
-        )
-        assigned_hosts = hosts_result.scalars().all()
+        # Effective hosts (direct + group assignments)
+        assigned_hosts = await get_effective_hosts(db, user.id)
 
         if not assigned_hosts:
             return PlainTextResponse("", status_code=200)

--- a/api/routers/sessions.py
+++ b/api/routers/sessions.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from core import get_db, write_audit_log
+from dependencies import require_role, require_totp_complete
+from models import AuditAction, SshSession, User
+from schemas import SessionsOut, SshSessionOut, ssh_session_out
+from session_tracker import terminate_session_process
+
+router = APIRouter(prefix="/sessions")
+
+RECENT_CLOSED_LIMIT = 20
+
+
+@router.get("")
+async def session_list(
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_totp_complete),
+) -> SessionsOut:
+    active_result = await db.execute(
+        select(SshSession)
+        .where(SshSession.ended_at.is_(None))
+        .order_by(SshSession.started_at.desc())
+    )
+    recent_result = await db.execute(
+        select(SshSession)
+        .where(SshSession.ended_at.is_not(None))
+        .order_by(SshSession.ended_at.desc())
+        .limit(RECENT_CLOSED_LIMIT)
+    )
+    return SessionsOut(
+        active=[ssh_session_out(s) for s in active_result.scalars().all()],
+        recent=[ssh_session_out(s) for s in recent_result.scalars().all()],
+    )
+
+
+@router.post("/{session_id}/terminate")
+async def terminate_session(
+    request: Request,
+    session_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_role("admin")),
+) -> SshSessionOut:
+    result = await db.execute(
+        select(SshSession).where(SshSession.id == session_id, SshSession.ended_at.is_(None))
+    )
+    session = result.scalar_one_or_none()
+    if not session:
+        raise HTTPException(status_code=404, detail="Active session not found")
+
+    # Signal the sshd child owning this connection. The /proc scan is
+    # synchronous — run it off the event loop.
+    signalled = await anyio.to_thread.run_sync(
+        terminate_session_process, session.source_ip, session.source_port
+    )
+
+    if not signalled:
+        # Keep the record open: in a split deployment the API cannot see
+        # sshd's PID namespace, so the connection may well still be live.
+        # Closing here would hide it from the page and falsely audit a
+        # termination; the log follower (or the startup sweep) closes the
+        # record when the connection actually ends.
+        raise HTTPException(status_code=409, detail="session_process_not_found")
+
+    session.ended_at = datetime.now(timezone.utc)
+    session.close_reason = "terminated"
+
+    await write_audit_log(
+        db,
+        actor_id=user.id,
+        action=AuditAction.SESSION_TERMINATED,
+        target_type="session",
+        target_id=session.id,
+        source_ip=request.client.host if request.client else None,
+        detail={
+            "username": session.username,
+            "session_source_ip": session.source_ip,
+        },
+    )
+    return ssh_session_out(session)

--- a/api/routers/setup.py
+++ b/api/routers/setup.py
@@ -14,6 +14,7 @@ from core import (
     get_runtime_setting,
     get_session_factory,
     hash_password,
+    issue_recovery_codes,
     limiter,
     totp_qr_b64,
     verify_totp,
@@ -22,7 +23,7 @@ from core import (
 from models import AuditAction, User, UserRole
 from dependencies import get_current_user
 from routers.auth import set_session_cookie
-from schemas import SessionOut, SetupIn, TOTPSetupOut, TOTPVerifyIn, user_out
+from schemas import EnrollOut, SessionOut, SetupIn, TOTPSetupOut, TOTPVerifyIn, user_out
 
 router = APIRouter(prefix="/setup")
 
@@ -185,7 +186,7 @@ async def setup_totp_verify(
     request: Request,
     body: TOTPVerifyIn,
     user: User = Depends(get_current_user),
-) -> SessionOut:
+) -> EnrollOut:
     if await _is_fully_setup():
         raise HTTPException(status_code=404)
 
@@ -216,6 +217,18 @@ async def setup_totp_verify(
             source_ip=request.client.host if request.client else None,
             detail={"source": "setup_wizard"},
         )
+
+        # Issue single-use recovery codes, returned exactly once.
+        codes = await issue_recovery_codes(db, user.id)
+        await write_audit_log(
+            db,
+            actor_id=user.id,
+            action=AuditAction.RECOVERY_CODES_GENERATED,
+            target_type="user",
+            target_id=user.id,
+            source_ip=request.client.host if request.client else None,
+            detail={"count": len(codes), "source": "setup_wizard"},
+        )
         await db.commit()
 
-    return SessionOut(user=user_out(db_user))
+    return EnrollOut(user=user_out(db_user), recovery_codes=codes)

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -11,20 +11,25 @@ from core import (
     USERNAME_RE,
     generate_ssh_keypair,
     get_db,
+    get_effective_hosts,
     get_runtime_setting,
     get_settings,
     get_ssh_host,
     hash_password,
+    issue_recovery_codes,
     parse_ssh_public_key,
+    unused_recovery_code_count,
     write_audit_log,
 )
 from dependencies import require_admin_or_self, require_role
-from models import AuditAction, Host, SSHKey, User, UserRole
+from models import AuditAction, Host, SSHKey, SshSession, User, UserRole
 from schemas import (
     ChangeRoleIn,
     CreateUserIn,
     GeneratedKeyOut,
     GenerateKeyIn,
+    GroupRef,
+    RecoveryCodesOut,
     SSHKeyOut,
     UploadKeyIn,
     UserDetailOut,
@@ -92,7 +97,7 @@ async def user_detail(
         select(User)
         .options(
             selectinload(User.ssh_keys),
-            selectinload(User.assigned_hosts).selectinload(Host.assigned_users),
+            selectinload(User.host_groups),
         )
         .where(User.id == user_id)
     )
@@ -100,11 +105,27 @@ async def user_detail(
     if not target_user:
         raise HTTPException(status_code=404, detail="User not found")
 
+    # Effective access: direct assignments plus host-group membership, so the
+    # generated SSH config always matches what the bastion will permit.
+    effective = await get_effective_hosts(db, target_user.id)
+    effective_ids = [h.id for h in effective]
+    hosts_with_assignments = []
+    if effective_ids:
+        hosts_result = await db.execute(
+            select(Host)
+            .options(selectinload(Host.assigned_users))
+            .where(Host.id.in_(effective_ids))
+            .order_by(Host.label)
+        )
+        hosts_with_assignments = hosts_result.scalars().all()
+
     settings = get_settings()
     return UserDetailOut(
         user=user_out(target_user),
         keys=[ssh_key_out(k) for k in target_user.ssh_keys if k.is_active],
-        assigned_hosts=[host_out(h) for h in target_user.assigned_hosts if h.is_active],
+        assigned_hosts=[host_out(h) for h in hosts_with_assignments],
+        host_groups=[GroupRef(id=g.id, name=g.name) for g in target_user.host_groups],
+        recovery_codes_remaining=await unused_recovery_code_count(db, target_user.id),
         ssh_host=await get_ssh_host(),
         ssh_port=settings.SSH_PORT,
         roles=[r.value for r in UserRole],
@@ -266,6 +287,15 @@ async def delete_user(
     target = await _get_user_or_404(db, user_id)
 
     username = target.username
+
+    # Detach retained session history explicitly: SQLite does not enforce the
+    # column's ondelete=SET NULL without PRAGMA foreign_keys, and no ORM
+    # relationship cascades onto SshSession. The denormalized username on the
+    # session row keeps the history attributable.
+    await db.execute(
+        update(SshSession).where(SshSession.user_id == user_id).values(user_id=None)
+    )
+
     await db.delete(target)
 
     await write_audit_log(
@@ -278,6 +308,37 @@ async def delete_user(
         detail={"username": username},
     )
     return Response(status_code=204)
+
+
+@router.post("/{user_id}/recovery-codes")
+async def regenerate_recovery_codes(
+    request: Request,
+    response: Response,
+    user_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_admin_or_self),
+) -> RecoveryCodesOut:
+    target = await _get_user_or_404(db, user_id)
+    if not target.is_active:
+        raise HTTPException(status_code=400, detail="Cannot generate recovery codes for inactive user")
+    if not target.totp_enrolled:
+        raise HTTPException(status_code=400, detail="User has not completed 2FA enrollment")
+
+    codes = await issue_recovery_codes(db, user_id)
+    await write_audit_log(
+        db,
+        actor_id=user.id,
+        action=AuditAction.RECOVERY_CODES_GENERATED,
+        target_type="user",
+        target_id=user_id,
+        source_ip=request.client.host if request.client else None,
+        detail={"count": len(codes), "source": "regenerated", "target_username": target.username},
+    )
+
+    # The codes are returned exactly once and stored only as keyed digests.
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    return RecoveryCodesOut(codes=codes)
 
 
 _LABEL_MAX_LEN = 100

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -11,7 +11,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from core import slugify
-from models import AuditLog, Host, SSHKey, User
+from models import AuditLog, Host, HostGroup, SSHKey, SshSession, User
 
 # ---------------------------------------------------------------------------
 # Users & keys
@@ -138,6 +138,82 @@ class DeployKeyOut(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Host groups
+# ---------------------------------------------------------------------------
+
+
+class HostRef(BaseModel):
+    id: str
+    label: str
+
+
+class GroupRef(BaseModel):
+    id: str
+    name: str
+
+
+class GroupOut(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    created_at: datetime
+    hosts: list[HostRef] = Field(default_factory=list)
+    users: list[UserRef] = Field(default_factory=list)
+
+
+def group_out(group: HostGroup) -> GroupOut:
+    return GroupOut(
+        id=group.id,
+        name=group.name,
+        description=group.description,
+        created_at=group.created_at,
+        hosts=[HostRef(id=h.id, label=h.label) for h in group.hosts],
+        users=[UserRef(id=u.id, username=u.username) for u in group.users],
+    )
+
+
+class CreateGroupIn(BaseModel):
+    name: str
+    description: str = ""
+
+
+# ---------------------------------------------------------------------------
+# SSH sessions
+# ---------------------------------------------------------------------------
+
+
+class SshSessionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    username: str
+    source_ip: str
+    source_port: int
+    key_fingerprint: str | None = None
+    started_at: datetime
+    ended_at: datetime | None = None
+    close_reason: str | None = None
+
+
+def ssh_session_out(session: SshSession) -> SshSessionOut:
+    return SshSessionOut.model_validate(session)
+
+
+class SessionsOut(BaseModel):
+    active: list[SshSessionOut]
+    recent: list[SshSessionOut]
+
+
+# ---------------------------------------------------------------------------
+# 2FA recovery codes
+# ---------------------------------------------------------------------------
+
+
+class RecoveryCodesOut(BaseModel):
+    codes: list[str]
+
+
+# ---------------------------------------------------------------------------
 # Audit
 # ---------------------------------------------------------------------------
 
@@ -190,6 +266,16 @@ class SessionOut(BaseModel):
     user: UserOut
 
 
+class EnrollOut(SessionOut):
+    """TOTP enrollment result: the session plus one-time recovery codes.
+
+    The codes are returned exactly once, at enrollment — they are stored
+    only as keyed digests server-side and can never be shown again.
+    """
+
+    recovery_codes: list[str] = Field(default_factory=list)
+
+
 class TOTPSetupOut(BaseModel):
     qr_png_b64: str
     secret: str
@@ -225,6 +311,8 @@ class UserDetailOut(BaseModel):
     user: UserOut
     keys: list[SSHKeyOut]
     assigned_hosts: list[HostOut]
+    host_groups: list[GroupRef] = Field(default_factory=list)
+    recovery_codes_remaining: int = 0
     ssh_host: str
     ssh_port: int
     roles: list[str]
@@ -233,6 +321,7 @@ class UserDetailOut(BaseModel):
 class DashboardOut(BaseModel):
     active_users: int
     active_hosts: int
+    active_sessions: int
     user_key_count: int
     recent_audit: list[AuditEntryOut]
     ssh_host: str

--- a/api/session_tracker.py
+++ b/api/session_tracker.py
@@ -1,0 +1,497 @@
+"""Live SSH session tracking.
+
+Tails the sshd log (written by ``sshd -E``, shared with the fail2ban
+sidecar) and turns authentication accepts / disconnects into SshSession
+rows plus session_opened / session_closed audit entries. Also locates the
+per-connection sshd child process via /proc so admins can terminate a
+session from the web UI (the unified container runs api and sshd in the
+same PID namespace).
+
+sshd -E log lines carry no timestamps, so event times are stamped when the
+line is read — the follower tails live, so this is accurate to the poll
+interval.
+"""
+
+import asyncio
+import ipaddress
+import logging
+import os
+import re
+import signal
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from core import get_session_factory, write_audit_log
+from models import AuditAction, SessionTrackerState, SshSession, User
+
+logger = logging.getLogger("callis")
+
+SSHD_LOG_PATH = os.environ.get("CALLIS_SSHD_LOG", "/var/log/callis/auth.log")
+POLL_INTERVAL = 2.0
+_MISSING_FILE_RETRY = 15.0
+
+_ACCEPT_RE = re.compile(
+    r"Accepted publickey for (?P<username>\S+) from (?P<ip>\S+) port (?P<port>\d+)"
+    r" ssh2(?:: (?P<key_type>\S+) (?P<fingerprint>\S+))?"
+)
+# Ordered: more specific patterns (with username) first. sshd usually logs
+# several of these per disconnect; the first one to match an open session
+# closes it and the rest become no-ops.
+_CLOSE_RES = (
+    re.compile(r"Disconnected from user (?P<username>\S+) (?P<ip>\S+) port (?P<port>\d+)"),
+    re.compile(r"Connection closed by user (?P<username>\S+) (?P<ip>\S+) port (?P<port>\d+)"),
+    re.compile(r"Received disconnect from (?P<ip>\S+) port (?P<port>\d+)"),
+    re.compile(r"Connection (?:closed|reset) by (?P<ip>[0-9a-fA-F.:]+) port (?P<port>\d+)"),
+)
+
+
+def parse_log_line(line: str) -> dict | None:
+    """Parse one sshd log line into an accept/close event, or None.
+
+    Pre-auth lines are ignored — they never correspond to an accepted
+    session (failed auth attempts are fail2ban's domain, and remain in the
+    sshd log and audit trail via key_used/VERBOSE logging).
+    """
+    if "[preauth]" in line:
+        return None
+
+    m = _ACCEPT_RE.search(line)
+    if m:
+        return {
+            "event": "accept",
+            "username": m.group("username"),
+            "ip": m.group("ip"),
+            "port": int(m.group("port")),
+            "fingerprint": m.group("fingerprint"),
+        }
+
+    for close_re in _CLOSE_RES:
+        m = close_re.search(line)
+        if m:
+            groups = m.groupdict()
+            return {
+                "event": "close",
+                "username": groups.get("username"),
+                "ip": groups["ip"],
+                "port": int(groups["port"]),
+            }
+    return None
+
+
+async def _handle_accept(db, event: dict) -> None:
+    # Idempotent: startup replay of the log window covering an API outage may
+    # re-read an accept line that was already processed. A live TCP peer
+    # (ip, port) is unique, so an existing open session means this exact
+    # connection is already tracked.
+    existing = await db.execute(
+        select(SshSession).where(
+            SshSession.ended_at.is_(None),
+            SshSession.username == event["username"],
+            SshSession.source_ip == event["ip"],
+            SshSession.source_port == event["port"],
+        )
+    )
+    if existing.scalars().first() is not None:
+        return
+
+    result = await db.execute(
+        select(User).where(User.username == event["username"], User.is_active == True)
+    )
+    user = result.scalar_one_or_none()
+
+    session = SshSession(
+        user_id=user.id if user else None,
+        username=event["username"],
+        source_ip=event["ip"],
+        source_port=event["port"],
+        key_fingerprint=event.get("fingerprint"),
+    )
+    db.add(session)
+    await db.flush()
+
+    await write_audit_log(
+        db,
+        actor_id=user.id if user else None,
+        action=AuditAction.SESSION_OPENED,
+        target_type="session",
+        target_id=session.id,
+        source_ip=event["ip"],
+        detail={
+            "username": event["username"],
+            "source_port": event["port"],
+            "fingerprint": event.get("fingerprint"),
+        },
+    )
+
+
+async def _handle_close(db, event: dict, reason: str = "disconnected") -> None:
+    query = (
+        select(SshSession)
+        .where(
+            SshSession.ended_at.is_(None),
+            SshSession.source_ip == event["ip"],
+            SshSession.source_port == event["port"],
+        )
+        .order_by(SshSession.started_at.desc())
+    )
+    if event.get("username"):
+        query = query.where(SshSession.username == event["username"])
+    result = await db.execute(query)
+    session = result.scalars().first()
+    if session is None:
+        return  # duplicate close line, or a connection opened before tracking
+
+    now = datetime.now(timezone.utc)
+    session.ended_at = now
+    session.close_reason = reason
+
+    started = session.started_at
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    await write_audit_log(
+        db,
+        actor_id=session.user_id,
+        action=AuditAction.SESSION_CLOSED,
+        target_type="session",
+        target_id=session.id,
+        source_ip=session.source_ip,
+        detail={
+            "username": session.username,
+            "duration_seconds": max(0, int((now - started).total_seconds())),
+            "reason": reason,
+        },
+    )
+
+
+async def apply_log_event(event: dict) -> None:
+    factory = get_session_factory()
+    async with factory() as db:
+        try:
+            if event["event"] == "accept":
+                await _handle_accept(db, event)
+            else:
+                await _handle_close(db, event)
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+
+async def close_stale_open_sessions() -> int:
+    """Close session records from a previous run whose connection is gone.
+
+    Called at startup. supervisord restarts the api process independently of
+    sshd, so open records are only closed when no established socket to the
+    session's peer remains (checked via /proc/net/tcp{,6} in the unified
+    container). Records whose connection is still alive stay open, so an
+    API-only restart does not hide live sessions. Where /proc is not
+    shared with sshd (split deployments), no socket is ever found and all
+    open records are closed — matching the pre-restart-tracking behaviour.
+    """
+    factory = get_session_factory()
+    async with factory() as db:
+        result = await db.execute(select(SshSession).where(SshSession.ended_at.is_(None)))
+        open_sessions = result.scalars().all()
+        now = datetime.now(timezone.utc)
+        stale_count = 0
+        for session in open_sessions:
+            if connection_still_established(session.source_ip, session.source_port):
+                continue
+            session.ended_at = now
+            session.close_reason = "server_restart"
+            stale_count += 1
+
+            # Keep the audit trail consistent with normal disconnects: every
+            # closed session gets a session_closed entry, whatever the cause.
+            started = session.started_at
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=timezone.utc)
+            await write_audit_log(
+                db,
+                actor_id=session.user_id,
+                action=AuditAction.SESSION_CLOSED,
+                target_type="session",
+                target_id=session.id,
+                source_ip=session.source_ip,
+                detail={
+                    "username": session.username,
+                    "duration_seconds": max(0, int((now - started).total_seconds())),
+                    "reason": "server_restart",
+                },
+            )
+        await db.commit()
+    if stale_count:
+        logger.info("Closed %d stale SSH session record(s) from a previous run", stale_count)
+    return stale_count
+
+
+async def _load_log_position() -> tuple[int, int] | None:
+    """Return the persisted (inode, offset) of the last processed log line.
+
+    Returns None (start at EOF) on any failure — bookkeeping must never
+    prevent the follower from starting.
+    """
+    try:
+        factory = get_session_factory()
+        async with factory() as db:
+            row = await db.get(SessionTrackerState, 1)
+            if row is not None and row.log_inode is not None and row.log_offset is not None:
+                return row.log_inode, row.log_offset
+    except Exception:
+        logger.exception("Failed to load persisted sshd log position")
+    return None
+
+
+async def _save_log_position(inode: int, offset: int) -> None:
+    factory = get_session_factory()
+    async with factory() as db:
+        row = await db.get(SessionTrackerState, 1)
+        if row is None:
+            row = SessionTrackerState(id=1)
+            db.add(row)
+        row.log_inode = inode
+        row.log_offset = offset
+        await db.commit()
+
+
+async def _save_log_position_safe(inode: int, offset: int) -> None:
+    """Persist the read position; bookkeeping must never kill the follower."""
+    try:
+        await _save_log_position(inode, offset)
+    except Exception:
+        logger.exception("Failed to persist sshd log position")
+
+
+def resolve_start_offset(saved: tuple[int, int] | None, inode: int, size: int) -> int:
+    """Where to start reading a newly opened log file.
+
+    Resume from the persisted offset when it belongs to this same file, so
+    sessions accepted while the API was down (sshd keeps running under
+    supervisord) are reconciled on restart. Otherwise — first run, rotation
+    while down, or truncation — start at EOF: replaying unbounded history
+    would fabricate session records with meaningless timestamps.
+    """
+    if saved is not None:
+        saved_inode, saved_offset = saved
+        if saved_inode == inode and 0 <= saved_offset <= size:
+            return saved_offset
+    return size
+
+
+async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_INTERVAL) -> None:
+    """Tail the sshd log forever, applying accept/close events to the DB.
+
+    Resumes from the last persisted position when the file is unchanged
+    (reconciling the API-downtime window; replayed events get stamped with
+    read time, so timestamps are off by at most the outage duration).
+    Survives log rotation and truncation, and idles quietly when the file
+    does not exist (split deployments, local development).
+    """
+    path = path or SSHD_LOG_PATH
+    f = None
+    cur_ino = 0
+    pos_dirty = False
+    warned_missing = False
+    try:
+        while True:
+            if f is None:
+                try:
+                    f = open(path, "rb")
+                    st = os.fstat(f.fileno())
+                    cur_ino = st.st_ino
+                    f.seek(resolve_start_offset(await _load_log_position(), st.st_ino, st.st_size))
+                    logger.info(
+                        "Session tracker following sshd log at %s from offset %d", path, f.tell()
+                    )
+                    warned_missing = False
+                except OSError:
+                    if f is not None:
+                        f.close()
+                        f = None
+                    if not warned_missing:
+                        logger.info(
+                            "sshd log %s not readable; session tracking idle until it appears",
+                            path,
+                        )
+                        warned_missing = True
+                    await asyncio.sleep(_MISSING_FILE_RETRY)
+                    continue
+
+            try:
+                st = os.stat(path)
+                if st.st_ino != cur_ino:
+                    # Rotated while running: we were current up to the switch,
+                    # so read the replacement file from the start.
+                    f.close()
+                    f = open(path, "rb")
+                    cur_ino = os.fstat(f.fileno()).st_ino
+                    pos_dirty = True
+                elif st.st_size < f.tell():
+                    # Truncated in place: start over.
+                    f.seek(0)
+                    pos_dirty = True
+            except OSError:
+                f.close()
+                f = None
+                continue
+
+            try:
+                raw = f.readline()
+                if not raw:
+                    if pos_dirty:
+                        await _save_log_position_safe(cur_ino, f.tell())
+                        pos_dirty = False
+                    await asyncio.sleep(poll_interval)
+                    continue
+                if not raw.endswith(b"\n"):
+                    # Partial line mid-write: rewind and retry next poll.
+                    f.seek(-len(raw), os.SEEK_CUR)
+                    await asyncio.sleep(poll_interval)
+                    continue
+            except OSError as exc:
+                logger.warning("Error reading sshd log %s: %s; reopening", path, exc)
+                f.close()
+                f = None
+                await asyncio.sleep(poll_interval)
+                continue
+
+            pos_dirty = True
+            event = parse_log_line(raw.decode("utf-8", errors="replace"))
+            if event is None:
+                # Yield so a burst of non-matching lines cannot starve the
+                # event loop (nothing below awaits on this path).
+                await asyncio.sleep(0)
+                continue
+            try:
+                await apply_log_event(event)
+            except Exception:
+                logger.exception("Failed to record SSH session event %r", event)
+            # Persist after every applied event so a crash replays at most
+            # the events since the last EOF idle, which the idempotent
+            # accept/close handlers absorb.
+            await _save_log_position_safe(cur_ino, f.tell())
+            pos_dirty = False
+    except asyncio.CancelledError:
+        raise
+    finally:
+        if f is not None:
+            f.close()
+
+
+# ---------------------------------------------------------------------------
+# Session process lookup and termination (/proc, unified container only)
+# ---------------------------------------------------------------------------
+
+
+def _candidate_hex_addrs(ip: str, port: int) -> set[str]:
+    """Render an IP:port as the hex forms used in /proc/net/tcp{,6}.
+
+    Addresses are stored as little-endian hex per 32-bit group. An IPv4
+    client can appear either in /proc/net/tcp or, as an IPv4-mapped IPv6
+    address, in /proc/net/tcp6 — both forms are returned.
+
+    Returns an empty set for values that are not valid IP addresses, so a
+    malformed stored source_ip can never crash the termination endpoint.
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return set()
+    port_hex = f"{port:04X}"
+    forms: set[str] = set()
+
+    def v4_hex(v4: ipaddress.IPv4Address) -> str:
+        return bytes(reversed(v4.packed)).hex().upper()
+
+    def v6_hex(v6: ipaddress.IPv6Address) -> str:
+        packed = v6.packed
+        groups = [packed[i : i + 4][::-1] for i in range(0, 16, 4)]
+        return b"".join(groups).hex().upper()
+
+    if addr.version == 4:
+        forms.add(f"{v4_hex(addr)}:{port_hex}")
+        forms.add(f"{v6_hex(ipaddress.IPv6Address('::ffff:' + ip))}:{port_hex}")
+    else:
+        forms.add(f"{v6_hex(addr)}:{port_hex}")
+        if addr.ipv4_mapped:
+            forms.add(f"{v4_hex(addr.ipv4_mapped)}:{port_hex}")
+    return forms
+
+
+_TCP_ESTABLISHED = "01"
+
+
+def find_socket_inodes(proc_net_text: str, ip: str, port: int) -> set[str]:
+    """Socket inodes in /proc/net/tcp{,6} content whose peer is ip:port."""
+    targets = _candidate_hex_addrs(ip, port)
+    inodes: set[str] = set()
+    for line in proc_net_text.splitlines()[1:]:
+        fields = line.split()
+        if len(fields) < 10:
+            continue
+        rem_address, state, inode = fields[2], fields[3], fields[9]
+        if state == _TCP_ESTABLISHED and rem_address.upper() in targets:
+            inodes.add(inode)
+    return inodes
+
+
+def _pids_for_inodes(inodes: set[str]) -> list[int]:
+    pids = []
+    socket_links = {f"socket:[{inode}]" for inode in inodes}
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        fd_dir = f"/proc/{entry}/fd"
+        try:
+            for fd in os.listdir(fd_dir):
+                try:
+                    if os.readlink(f"{fd_dir}/{fd}") in socket_links:
+                        pids.append(int(entry))
+                        break
+                except OSError:
+                    continue
+        except OSError:
+            continue  # process exited or not ours
+    return pids
+
+
+def _socket_inodes_for_peer(ip: str, port: int) -> set[str]:
+    """Inodes of established sockets whose peer is ip:port, from /proc."""
+    inodes: set[str] = set()
+    for table in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(table) as fh:
+                inodes |= find_socket_inodes(fh.read(), ip, port)
+        except OSError:
+            continue
+    return inodes
+
+
+def connection_still_established(ip: str, port: int) -> bool:
+    """True if an established socket to ip:port still exists on this host."""
+    return bool(_socket_inodes_for_peer(ip, port))
+
+
+def terminate_session_process(ip: str, port: int) -> bool:
+    """SIGTERM the sshd child holding the connection from ip:port.
+
+    Returns True if at least one process was signalled. Only works in the
+    unified container (api shares a PID namespace with sshd and runs as
+    root); returns False otherwise.
+    """
+    inodes = _socket_inodes_for_peer(ip, port)
+    if not inodes:
+        return False
+
+    signalled = False
+    for pid in _pids_for_inodes(inodes):
+        if pid == os.getpid():
+            continue
+        try:
+            os.kill(pid, signal.SIGTERM)
+            signalled = True
+            logger.info("Terminated SSH session process pid=%d (%s:%d)", pid, ip, port)
+        except OSError as exc:
+            logger.warning("Could not signal pid %d for %s:%d: %s", pid, ip, port, exc)
+    return signalled

--- a/api/session_tracker.py
+++ b/api/session_tracker.py
@@ -30,6 +30,7 @@ logger = logging.getLogger("callis")
 SSHD_LOG_PATH = os.environ.get("CALLIS_SSHD_LOG", "/var/log/callis/auth.log")
 POLL_INTERVAL = 2.0
 _MISSING_FILE_RETRY = 15.0
+_EVENT_RETRY_LIMIT = 5
 
 _ACCEPT_RE = re.compile(
     r"Accepted publickey for (?P<username>\S+) from (?P<ip>\S+) port (?P<port>\d+)"
@@ -263,19 +264,29 @@ async def _save_log_position_safe(inode: int, offset: int) -> None:
         logger.exception("Failed to persist sshd log position")
 
 
-def resolve_start_offset(saved: tuple[int, int] | None, inode: int, size: int) -> int:
+def resolve_start_offset(
+    saved: tuple[int, int] | None,
+    inode: int,
+    size: int,
+    appeared_after_absence: bool = False,
+) -> int:
     """Where to start reading a newly opened log file.
 
     Resume from the persisted offset when it belongs to this same file, so
     sessions accepted while the API was down (sshd keeps running under
-    supervisord) are reconciled on restart. Otherwise — first run, rotation
-    while down, or truncation — start at EOF: replaying unbounded history
-    would fabricate session records with meaningless timestamps.
+    supervisord) are reconciled on restart. A file that appeared after the
+    follower found it missing is brand new (sshd just created it) — read it
+    from the start so connections accepted before our retry woke up are not
+    dropped. Otherwise — first run against an existing log, rotation while
+    down, or truncation — start at EOF: replaying unbounded history would
+    fabricate session records with meaningless timestamps.
     """
     if saved is not None:
         saved_inode, saved_offset = saved
         if saved_inode == inode and 0 <= saved_offset <= size:
             return saved_offset
+    if appeared_after_absence:
+        return 0
     return size
 
 
@@ -293,6 +304,9 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
     cur_ino = 0
     pos_dirty = False
     warned_missing = False
+    file_was_missing = False
+    retry_pos = -1
+    retry_count = 0
     try:
         while True:
             if f is None:
@@ -300,15 +314,24 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
                     f = open(path, "rb")
                     st = os.fstat(f.fileno())
                     cur_ino = st.st_ino
-                    f.seek(resolve_start_offset(await _load_log_position(), st.st_ino, st.st_size))
+                    f.seek(
+                        resolve_start_offset(
+                            await _load_log_position(),
+                            st.st_ino,
+                            st.st_size,
+                            appeared_after_absence=file_was_missing,
+                        )
+                    )
                     logger.info(
                         "Session tracker following sshd log at %s from offset %d", path, f.tell()
                     )
                     warned_missing = False
+                    file_was_missing = False
                 except OSError:
                     if f is not None:
                         f.close()
                         f = None
+                    file_was_missing = True
                     if not warned_missing:
                         logger.info(
                             "sshd log %s not readable; session tracking idle until it appears",
@@ -357,6 +380,7 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
                 continue
 
             pos_dirty = True
+            line_start = f.tell() - len(raw)
             event = parse_log_line(raw.decode("utf-8", errors="replace"))
             if event is None:
                 # Yield so a burst of non-matching lines cannot starve the
@@ -365,11 +389,33 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
                 continue
             try:
                 await apply_log_event(event)
+                retry_pos, retry_count = -1, 0
             except Exception:
-                logger.exception("Failed to record SSH session event %r", event)
-            # Persist after every applied event so a crash replays at most
-            # the events since the last EOF idle, which the idempotent
-            # accept/close handlers absorb.
+                # Transient failures (e.g. SQLite "database is locked") must
+                # not lose the event: rewind and retry the same line, bounded
+                # so a permanently failing line cannot wedge the tracker.
+                if line_start == retry_pos:
+                    retry_count += 1
+                else:
+                    retry_pos, retry_count = line_start, 1
+                if retry_count <= _EVENT_RETRY_LIMIT:
+                    logger.exception(
+                        "Failed to record SSH session event %r (attempt %d); retrying",
+                        event,
+                        retry_count,
+                    )
+                    f.seek(line_start)
+                    await asyncio.sleep(poll_interval)
+                    continue
+                logger.exception(
+                    "Failed to record SSH session event %r after %d attempts; skipping line",
+                    event,
+                    retry_count,
+                )
+                retry_pos, retry_count = -1, 0
+            # Persist only after the event was applied (or given up on) so a
+            # crash replays at most the events since the last persist, which
+            # the idempotent accept/close handlers absorb.
             await _save_log_position_safe(cur_ino, f.tell())
             pos_dirty = False
     except asyncio.CancelledError:

--- a/api/session_tracker.py
+++ b/api/session_tracker.py
@@ -165,7 +165,22 @@ async def _handle_close(db, event: dict, reason: str = "disconnected") -> None:
     )
 
 
-async def apply_log_event(event: dict) -> None:
+async def _set_position_row(db, inode: int, offset: int) -> None:
+    row = await db.get(SessionTrackerState, 1)
+    if row is None:
+        row = SessionTrackerState(id=1)
+        db.add(row)
+    row.log_inode = inode
+    row.log_offset = offset
+
+
+async def apply_log_event(event: dict, position: tuple[int, int] | None = None) -> None:
+    """Apply one accept/close event; optionally advance the read position.
+
+    When ``position`` is given it is written in the SAME transaction as the
+    event, so a committed event can never be replayed after a crash — the
+    persisted offset always points past exactly the events that committed.
+    """
     factory = get_session_factory()
     async with factory() as db:
         try:
@@ -173,6 +188,8 @@ async def apply_log_event(event: dict) -> None:
                 await _handle_accept(db, event)
             else:
                 await _handle_close(db, event)
+            if position is not None:
+                await _set_position_row(db, *position)
             await db.commit()
         except Exception:
             await db.rollback()
@@ -247,12 +264,7 @@ async def _load_log_position() -> tuple[int, int] | None:
 async def _save_log_position(inode: int, offset: int) -> None:
     factory = get_session_factory()
     async with factory() as db:
-        row = await db.get(SessionTrackerState, 1)
-        if row is None:
-            row = SessionTrackerState(id=1)
-            db.add(row)
-        row.log_inode = inode
-        row.log_offset = offset
+        await _set_position_row(db, inode, offset)
         await db.commit()
 
 
@@ -388,8 +400,13 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
                 await asyncio.sleep(0)
                 continue
             try:
-                await apply_log_event(event)
+                # Event and offset commit atomically: a committed event is
+                # never replayed, and a failed one leaves the offset behind
+                # so the retry below re-reads the same line.
+                await apply_log_event(event, position=(cur_ino, f.tell()))
                 retry_pos, retry_count = -1, 0
+                pos_dirty = False
+                continue
             except Exception:
                 # Transient failures (e.g. SQLite "database is locked") must
                 # not lose the event: rewind and retry the same line, bounded
@@ -413,11 +430,9 @@ async def follow_sshd_log(path: str | None = None, poll_interval: float = POLL_I
                     retry_count,
                 )
                 retry_pos, retry_count = -1, 0
-            # Persist only after the event was applied (or given up on) so a
-            # crash replays at most the events since the last persist, which
-            # the idempotent accept/close handlers absorb.
-            await _save_log_position_safe(cur_ino, f.tell())
-            pos_dirty = False
+                # Deliberately skipping this line: advance the offset past it.
+                await _save_log_position_safe(cur_ino, f.tell())
+                pos_dirty = False
     except asyncio.CancelledError:
         raise
     finally:

--- a/api/tests/test_api_v1.py
+++ b/api/tests/test_api_v1.py
@@ -350,3 +350,167 @@ async def test_unauthenticated_requests_rejected(client):
         assert (await fresh.get("/api/v1/meta")).status_code == 200
         assert (await fresh.get("/health")).status_code == 200
         assert (await fresh.get("/install.sh")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_recovery_codes_flow(client):
+    # Complete the wizard by hand so we can capture the enrollment response
+    r = await client.post(
+        "/api/v1/setup",
+        json={
+            "username": "admin",
+            "password": ADMIN_PASSWORD,
+            "password_confirm": ADMIN_PASSWORD,
+            "display_name": "Administrator",
+        },
+    )
+    assert r.status_code == 201, r.text
+    secret = (await client.get("/api/v1/setup/totp")).json()["secret"]
+    r = await client.post(
+        "/api/v1/setup/totp/verify", json={"totp_code": pyotp.TOTP(secret).now()}
+    )
+    assert r.status_code == 200, r.text
+    codes = r.json()["recovery_codes"]
+    assert len(codes) == 10
+
+    admin_id = (await client.get("/api/v1/auth/me")).json()["user"]["id"]
+
+    # A recovery code substitutes for the TOTP code at login...
+    await client.post("/api/v1/auth/logout")
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": codes[0]},
+    )
+    assert r.status_code == 200, r.text
+
+    # ...exactly once
+    await client.post("/api/v1/auth/logout")
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": codes[0]},
+    )
+    assert r.status_code == 401
+
+    # TOTP login still works, and the profile reports remaining codes
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": pyotp.TOTP(secret).now()},
+    )
+    assert r.status_code == 200, r.text
+    r = await client.get(f"/api/v1/users/{admin_id}")
+    assert r.json()["recovery_codes_remaining"] == 9
+
+    # The use is audited
+    r = await client.get("/api/v1/audit", params={"action": "recovery_code_used"})
+    assert r.json()["total"] == 1
+
+    # Regeneration invalidates the old set
+    r = await client.post(f"/api/v1/users/{admin_id}/recovery-codes")
+    assert r.status_code == 200, r.text
+    new_codes = r.json()["codes"]
+    assert len(new_codes) == 10
+    assert set(new_codes).isdisjoint(codes)
+
+    await client.post("/api/v1/auth/logout")
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": codes[1]},
+    )
+    assert r.status_code == 401  # old code dead
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": new_codes[0]},
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_host_groups_flow(client):
+    await complete_setup(client)
+
+    r = await client.post(
+        "/api/v1/hosts",
+        json={"label": "Prod Web", "hostname": "web.internal", "port": 22},
+    )
+    assert r.status_code == 201, r.text
+    host_id = r.json()["id"]
+
+    r = await client.post(
+        "/api/v1/users",
+        json={"username": "bob", "password": USER_PASSWORD},
+    )
+    assert r.status_code == 201, r.text
+    bob_id = r.json()["id"]
+
+    # Create a group; duplicate names are rejected
+    r = await client.post("/api/v1/groups", json={"name": "prod", "description": "Production"})
+    assert r.status_code == 201, r.text
+    group_id = r.json()["id"]
+    r = await client.post("/api/v1/groups", json={"name": "prod"})
+    assert r.status_code == 400
+
+    # Add the host and bob to the group
+    r = await client.post(f"/api/v1/groups/{group_id}/hosts/{host_id}")
+    assert r.status_code == 200 and [h["id"] for h in r.json()["hosts"]] == [host_id]
+    r = await client.post(f"/api/v1/groups/{group_id}/users/{bob_id}")
+    assert r.status_code == 200 and [u["id"] for u in r.json()["users"]] == [bob_id]
+
+    r = await client.get("/api/v1/groups")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+    # Bob's effective access now includes the group's host
+    r = await client.get(f"/api/v1/users/{bob_id}")
+    body = r.json()
+    assert [h["label"] for h in body["assigned_hosts"]] == ["Prod Web"]
+    assert [g["name"] for g in body["host_groups"]] == ["prod"]
+
+    # Removing the host from the group revokes the group-granted access
+    r = await client.delete(f"/api/v1/groups/{group_id}/hosts/{host_id}")
+    assert r.status_code == 200 and r.json()["hosts"] == []
+    r = await client.get(f"/api/v1/users/{bob_id}")
+    assert r.json()["assigned_hosts"] == []
+
+    # Delete the group
+    r = await client.delete(f"/api/v1/groups/{group_id}")
+    assert r.status_code == 204
+    assert (await client.get("/api/v1/groups")).json() == []
+
+    # Membership changes are audited
+    r = await client.get("/api/v1/audit", params={"action": "group_host_added"})
+    assert r.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sessions_endpoints(client):
+    from models import SshSession
+
+    await complete_setup(client)
+
+    r = await client.get("/api/v1/sessions")
+    assert r.status_code == 200
+    assert r.json() == {"active": [], "recent": []}
+
+    r = await client.post("/api/v1/sessions/nonexistent/terminate")
+    assert r.status_code == 404
+
+    # Seed an open session row as the tracker would
+    factory = core.get_session_factory()
+    async with factory() as db:
+        db.add(
+            SshSession(username="alice", source_ip="203.0.113.5", source_port=50000)
+        )
+        await db.commit()
+
+    r = await client.get("/api/v1/sessions")
+    active = r.json()["active"]
+    assert len(active) == 1 and active[0]["username"] == "alice"
+    session_id = active[0]["id"]
+
+    # No process owns that connection in the test environment: the record
+    # must stay open and the endpoint must say so instead of faking a close.
+    r = await client.post(f"/api/v1/sessions/{session_id}/terminate")
+    assert r.status_code == 409
+    assert r.json()["detail"] == "session_process_not_found"
+    r = await client.get("/api/v1/sessions")
+    assert len(r.json()["active"]) == 1

--- a/api/tests/test_host_groups.py
+++ b/api/tests/test_host_groups.py
@@ -1,0 +1,121 @@
+import asyncio
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from core import get_effective_hosts, hash_password
+from models import Base, Host, HostGroup, User, UserRole
+
+
+async def _make_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _user(username: str) -> User:
+    return User(
+        username=username,
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        role=UserRole.readonly,
+        totp_enrolled=True,
+    )
+
+
+def test_effective_hosts_union_of_direct_and_group():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                alice = _user("alice")
+                direct_host = Host(label="Direct", hostname="direct.internal", port=22)
+                group_host = Host(label="Grouped", hostname="grouped.internal", port=22)
+                both_host = Host(label="Both", hostname="both.internal", port=22)
+                other_host = Host(label="Other", hostname="other.internal", port=22)
+
+                alice.assigned_hosts.append(direct_host)
+                alice.assigned_hosts.append(both_host)
+
+                group = HostGroup(name="prod")
+                group.hosts.extend([group_host, both_host])
+                group.users.append(alice)
+
+                db.add_all([alice, direct_host, group_host, both_host, other_host, group])
+                await db.commit()
+
+                hosts = await get_effective_hosts(db, alice.id)
+                labels = sorted(h.label for h in hosts)
+                # Union without duplicates; unassigned host excluded
+                assert labels == ["Both", "Direct", "Grouped"]
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_effective_hosts_excludes_inactive_hosts():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                alice = _user("alice")
+                inactive_direct = Host(label="Old Direct", hostname="a.internal", port=22, is_active=False)
+                inactive_grouped = Host(label="Old Grouped", hostname="b.internal", port=22, is_active=False)
+                alice.assigned_hosts.append(inactive_direct)
+                group = HostGroup(name="stale")
+                group.hosts.append(inactive_grouped)
+                group.users.append(alice)
+                db.add_all([alice, inactive_direct, inactive_grouped, group])
+                await db.commit()
+
+                assert await get_effective_hosts(db, alice.id) == []
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_effective_hosts_isolated_between_users():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                alice = _user("alice")
+                bob = _user("bob")
+                host = Host(label="Prod Web", hostname="web.internal", port=22)
+                group = HostGroup(name="prod")
+                group.hosts.append(host)
+                group.users.append(alice)
+                db.add_all([alice, bob, host, group])
+                await db.commit()
+
+                assert [h.label for h in await get_effective_hosts(db, alice.id)] == ["Prod Web"]
+                assert await get_effective_hosts(db, bob.id) == []
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_group_deletion_revokes_group_access():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                alice = _user("alice")
+                host = Host(label="Prod Web", hostname="web.internal", port=22)
+                group = HostGroup(name="prod")
+                group.hosts.append(host)
+                group.users.append(alice)
+                db.add_all([alice, host, group])
+                await db.commit()
+
+                assert len(await get_effective_hosts(db, alice.id)) == 1
+                await db.delete(group)
+                await db.commit()
+                assert await get_effective_hosts(db, alice.id) == []
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())

--- a/api/tests/test_recovery_codes.py
+++ b/api/tests/test_recovery_codes.py
@@ -1,0 +1,146 @@
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from core import (
+    RECOVERY_CODE_COUNT,
+    consume_recovery_code,
+    generate_recovery_code,
+    hash_password,
+    hash_recovery_code,
+    issue_recovery_codes,
+    looks_like_recovery_code,
+    normalize_recovery_code,
+    unused_recovery_code_count,
+)
+from models import Base, RecoveryCode, User, UserRole
+
+
+def test_generate_recovery_code_format():
+    for _ in range(50):
+        code = generate_recovery_code()
+        assert len(code) == 11
+        assert code[5] == "-"
+        normalized = normalize_recovery_code(code)
+        assert len(normalized) == 10
+        # No ambiguous characters
+        for ch in normalized:
+            assert ch in "23456789abcdefghjkmnpqrstuvwxyz"
+
+
+def test_generate_recovery_codes_unique():
+    codes = {generate_recovery_code() for _ in range(100)}
+    assert len(codes) == 100
+
+
+def test_normalize_recovery_code():
+    assert normalize_recovery_code("  AbCd2-34567 ") == "abcd234567"
+    assert normalize_recovery_code("abcd2 34567") == "abcd234567"
+
+
+def test_hash_recovery_code_ignores_formatting():
+    code = generate_recovery_code()
+    assert hash_recovery_code(code) == hash_recovery_code(code.replace("-", "").upper())
+    assert hash_recovery_code(code) != hash_recovery_code(generate_recovery_code())
+    assert len(hash_recovery_code(code)) == 64  # hex SHA-256
+
+
+def test_looks_like_recovery_code():
+    assert looks_like_recovery_code(generate_recovery_code())
+    assert looks_like_recovery_code("abcd2-34567")
+    # The alphabet contains digits, so a (rare) all-numeric issued code
+    # must still be recognized — length alone distinguishes it from TOTP.
+    assert looks_like_recovery_code("23456-78923")
+    assert not looks_like_recovery_code("123456")       # TOTP code
+    assert not looks_like_recovery_code("")
+    assert not looks_like_recovery_code("abc")           # too short
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _make_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _make_user(db) -> User:
+    user = User(
+        username="alice",
+        display_name="Alice",
+        hashed_password=hash_password("password123"),
+        role=UserRole.admin,
+        totp_enrolled=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+def test_issue_and_consume_recovery_code():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                user = await _make_user(db)
+                codes = await issue_recovery_codes(db, user.id)
+                assert len(codes) == RECOVERY_CODE_COUNT
+                assert await unused_recovery_code_count(db, user.id) == RECOVERY_CODE_COUNT
+
+                # Wrong code fails, right code succeeds exactly once
+                assert not await consume_recovery_code(db, user.id, "zzzzz-zzzzz")
+                assert await consume_recovery_code(db, user.id, codes[0])
+                assert not await consume_recovery_code(db, user.id, codes[0])
+                assert await unused_recovery_code_count(db, user.id) == RECOVERY_CODE_COUNT - 1
+
+                # Formatting-insensitive consumption
+                assert await consume_recovery_code(db, user.id, codes[1].replace("-", "").upper())
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+
+def test_reissue_invalidates_old_codes():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                user = await _make_user(db)
+                old_codes = await issue_recovery_codes(db, user.id)
+                new_codes = await issue_recovery_codes(db, user.id)
+
+                assert await unused_recovery_code_count(db, user.id) == RECOVERY_CODE_COUNT
+                assert not await consume_recovery_code(db, user.id, old_codes[0])
+                assert await consume_recovery_code(db, user.id, new_codes[0])
+
+                # Only the new set exists in the DB
+                result = await db.execute(select(RecoveryCode).where(RecoveryCode.user_id == user.id))
+                assert len(result.scalars().all()) == RECOVERY_CODE_COUNT
+        finally:
+            await engine.dispose()
+
+    _run(scenario())
+
+
+def test_codes_are_stored_hashed():
+    async def scenario():
+        engine, factory = await _make_db()
+        try:
+            async with factory() as db:
+                user = await _make_user(db)
+                codes = await issue_recovery_codes(db, user.id)
+                result = await db.execute(select(RecoveryCode))
+                stored = {rc.code_digest for rc in result.scalars().all()}
+                for code in codes:
+                    assert code not in stored
+                    assert normalize_recovery_code(code) not in stored
+                    assert hash_recovery_code(code) in stored
+        finally:
+            await engine.dispose()
+
+    _run(scenario())

--- a/api/tests/test_session_tracker.py
+++ b/api/tests/test_session_tracker.py
@@ -175,6 +175,16 @@ def test_resolve_start_offset():
     assert resolve_start_offset((7, 500), inode=7, size=500) == 500
 
 
+def test_resolve_start_offset_file_appeared_after_absence():
+    # A file that appeared after being missing is brand new: read from 0 so
+    # connections accepted before the retry woke up are not dropped
+    assert resolve_start_offset(None, inode=7, size=500, appeared_after_absence=True) == 0
+    # ...but a matching saved position still wins (restart during the window)
+    assert resolve_start_offset((7, 200), inode=7, size=500, appeared_after_absence=True) == 200
+    # Stale state from a different file: still read the new file from 0
+    assert resolve_start_offset((6, 200), inode=7, size=500, appeared_after_absence=True) == 0
+
+
 def test_accept_for_unknown_user_still_recorded(monkeypatch):
     async def scenario():
         engine, factory = await _make_db()

--- a/api/tests/test_session_tracker.py
+++ b/api/tests/test_session_tracker.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 import core
 import session_tracker
 from core import hash_password
-from models import AuditAction, AuditLog, Base, SshSession, User, UserRole
+from models import AuditAction, AuditLog, Base, SessionTrackerState, SshSession, User, UserRole
 from session_tracker import (
     _candidate_hex_addrs,
     close_stale_open_sessions,
@@ -156,6 +156,30 @@ def test_accept_is_idempotent_on_replay(monkeypatch):
                 assert len(sessions) == 1
                 audit = (await db.execute(select(AuditLog))).scalars().all()
                 assert [a.action for a in audit] == [AuditAction.SESSION_OPENED]
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_event_and_position_commit_atomically(monkeypatch):
+    """A committed event always carries its offset, so replay cannot duplicate."""
+
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        try:
+            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
+
+            async with factory() as db:
+                state = await db.get(SessionTrackerState, 1)
+                assert (state.log_inode, state.log_offset) == (7, 123)
+
+            # Replaying the same accept (crash before a later offset persisted)
+            # is a no-op for rows and audit alike
+            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
+            async with factory() as db:
+                assert len((await db.execute(select(SshSession))).scalars().all()) == 1
         finally:
             await engine.dispose()
 

--- a/api/tests/test_session_tracker.py
+++ b/api/tests/test_session_tracker.py
@@ -1,0 +1,297 @@
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import core
+import session_tracker
+from core import hash_password
+from models import AuditAction, AuditLog, Base, SshSession, User, UserRole
+from session_tracker import (
+    _candidate_hex_addrs,
+    close_stale_open_sessions,
+    find_socket_inodes,
+    parse_log_line,
+    resolve_start_offset,
+)
+
+
+# ---------------------------------------------------------------------------
+# Log line parsing
+# ---------------------------------------------------------------------------
+
+ACCEPT_LINE = (
+    "Accepted publickey for alice from 172.18.0.1 port 51234 ssh2: "
+    "ED25519 SHA256:AbCdEf123456"
+)
+
+
+def test_parse_accept_line():
+    event = parse_log_line(ACCEPT_LINE)
+    assert event == {
+        "event": "accept",
+        "username": "alice",
+        "ip": "172.18.0.1",
+        "port": 51234,
+        "fingerprint": "SHA256:AbCdEf123456",
+    }
+
+
+def test_parse_accept_line_without_key_info():
+    event = parse_log_line("Accepted publickey for bob from 10.0.0.5 port 40000 ssh2")
+    assert event["event"] == "accept"
+    assert event["username"] == "bob"
+    assert event["fingerprint"] is None
+
+
+def test_parse_close_lines():
+    for line, username in (
+        ("Disconnected from user alice 172.18.0.1 port 51234", "alice"),
+        ("Connection closed by user alice 172.18.0.1 port 51234", "alice"),
+        ("Received disconnect from 172.18.0.1 port 51234:11: disconnected by user", None),
+        ("Connection reset by 172.18.0.1 port 51234", None),
+    ):
+        event = parse_log_line(line)
+        assert event is not None, line
+        assert event["event"] == "close", line
+        assert event["ip"] == "172.18.0.1"
+        assert event["port"] == 51234
+        assert event.get("username") == username, line
+
+
+def test_parse_ignores_preauth_and_noise():
+    assert parse_log_line("Connection closed by authenticating user bob 1.2.3.4 port 9 [preauth]") is None
+    assert parse_log_line("Received disconnect from 1.2.3.4 port 9:11: bye [preauth]") is None
+    assert parse_log_line("Failed publickey for bob from 1.2.3.4 port 9 ssh2 [preauth]") is None
+    assert parse_log_line("Server listening on 0.0.0.0 port 22.") is None
+    assert parse_log_line("") is None
+
+
+def test_parse_tolerates_syslog_prefix():
+    event = parse_log_line("Jul 19 12:00:00 bastion sshd[123]: " + ACCEPT_LINE)
+    assert event is not None and event["event"] == "accept"
+
+
+# ---------------------------------------------------------------------------
+# DB event application
+# ---------------------------------------------------------------------------
+
+
+async def _make_db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _patch_factory(monkeypatch, factory):
+    monkeypatch.setattr(core, "get_session_factory", lambda: factory)
+    monkeypatch.setattr(session_tracker, "get_session_factory", lambda: factory)
+
+
+def test_accept_and_close_lifecycle(monkeypatch):
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        try:
+            async with factory() as db:
+                db.add(
+                    User(
+                        username="alice",
+                        display_name="Alice",
+                        hashed_password=hash_password("password123"),
+                        role=UserRole.readonly,
+                        totp_enrolled=True,
+                    )
+                )
+                await db.commit()
+
+            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE))
+
+            async with factory() as db:
+                sessions = (await db.execute(select(SshSession))).scalars().all()
+                assert len(sessions) == 1
+                s = sessions[0]
+                assert s.username == "alice"
+                assert s.user_id is not None
+                assert s.ended_at is None
+                assert s.key_fingerprint == "SHA256:AbCdEf123456"
+
+                audit = (await db.execute(select(AuditLog))).scalars().all()
+                assert [a.action for a in audit] == [AuditAction.SESSION_OPENED]
+
+            await session_tracker.apply_log_event(
+                parse_log_line("Disconnected from user alice 172.18.0.1 port 51234")
+            )
+            # A duplicate close line must be a no-op
+            await session_tracker.apply_log_event(
+                parse_log_line("Received disconnect from 172.18.0.1 port 51234:11: bye")
+            )
+
+            async with factory() as db:
+                s = (await db.execute(select(SshSession))).scalars().one()
+                assert s.ended_at is not None
+                assert s.close_reason == "disconnected"
+                actions = [a.action for a in (await db.execute(select(AuditLog))).scalars().all()]
+                assert actions.count(AuditAction.SESSION_CLOSED) == 1
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_accept_is_idempotent_on_replay(monkeypatch):
+    """Re-reading an already-processed accept line must not duplicate rows."""
+
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        try:
+            event = parse_log_line(ACCEPT_LINE)
+            await session_tracker.apply_log_event(event)
+            await session_tracker.apply_log_event(event)
+
+            async with factory() as db:
+                sessions = (await db.execute(select(SshSession))).scalars().all()
+                assert len(sessions) == 1
+                audit = (await db.execute(select(AuditLog))).scalars().all()
+                assert [a.action for a in audit] == [AuditAction.SESSION_OPENED]
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_resolve_start_offset():
+    # No saved state (first run): start at EOF
+    assert resolve_start_offset(None, inode=7, size=500) == 500
+    # Same file, valid offset: resume (reconciles the API-downtime window)
+    assert resolve_start_offset((7, 200), inode=7, size=500) == 200
+    # Rotated (different inode): EOF — unbounded replay would fabricate history
+    assert resolve_start_offset((6, 200), inode=7, size=500) == 500
+    # Truncated below the saved offset: EOF
+    assert resolve_start_offset((7, 900), inode=7, size=500) == 500
+    # Saved offset at exactly EOF is valid
+    assert resolve_start_offset((7, 500), inode=7, size=500) == 500
+
+
+def test_accept_for_unknown_user_still_recorded(monkeypatch):
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        try:
+            await session_tracker.apply_log_event(
+                parse_log_line("Accepted publickey for ghost from 10.0.0.9 port 1024 ssh2")
+            )
+            async with factory() as db:
+                s = (await db.execute(select(SshSession))).scalars().one()
+                assert s.username == "ghost"
+                assert s.user_id is None
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_close_stale_open_sessions(monkeypatch):
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        # No established socket exists for these peers in this test env
+        monkeypatch.setattr(session_tracker, "connection_still_established", lambda ip, port: False)
+        try:
+            async with factory() as db:
+                db.add(SshSession(username="alice", source_ip="1.2.3.4", source_port=1))
+                db.add(SshSession(username="bob", source_ip="1.2.3.4", source_port=2))
+                await db.commit()
+
+            assert await close_stale_open_sessions() == 2
+            assert await close_stale_open_sessions() == 0
+
+            async with factory() as db:
+                sessions = (await db.execute(select(SshSession))).scalars().all()
+                assert all(s.ended_at is not None for s in sessions)
+                assert all(s.close_reason == "server_restart" for s in sessions)
+
+                # Each stale closure must be audited like a normal disconnect
+                audit = (await db.execute(select(AuditLog))).scalars().all()
+                closed = [a for a in audit if a.action == AuditAction.SESSION_CLOSED]
+                assert len(closed) == 2
+                assert all(a.detail["reason"] == "server_restart" for a in closed)
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_close_stale_keeps_live_connections_open(monkeypatch):
+    """API-only restart: sessions with a still-established socket stay open."""
+
+    async def scenario():
+        engine, factory = await _make_db()
+        _patch_factory(monkeypatch, factory)
+        monkeypatch.setattr(
+            session_tracker,
+            "connection_still_established",
+            lambda ip, port: port == 1,  # only alice's connection is still alive
+        )
+        try:
+            async with factory() as db:
+                db.add(SshSession(username="alice", source_ip="1.2.3.4", source_port=1))
+                db.add(SshSession(username="bob", source_ip="1.2.3.4", source_port=2))
+                await db.commit()
+
+            assert await close_stale_open_sessions() == 1
+
+            async with factory() as db:
+                sessions = (await db.execute(select(SshSession))).scalars().all()
+                by_user = {s.username: s for s in sessions}
+                assert by_user["alice"].ended_at is None
+                assert by_user["bob"].ended_at is not None
+                assert by_user["bob"].close_reason == "server_restart"
+        finally:
+            await engine.dispose()
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# /proc/net/tcp parsing
+# ---------------------------------------------------------------------------
+
+# 172.18.0.1 = AC 12 00 01 → little-endian hex 010012AC; port 51234 = 0xC822
+_PROC_NET_TCP = """\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0B00007F:0016 010012AC:C822 01 00000000:00000000 00:00000000 00000000     0        0 67890 1 0000000000000000 20 4 30 10 -1
+   2: 0B00007F:0016 010012AC:C823 01 00000000:00000000 00:00000000 00000000     0        0 67891 1 0000000000000000 20 4 30 10 -1
+"""
+
+
+def test_find_socket_inodes_matches_peer():
+    assert find_socket_inodes(_PROC_NET_TCP, "172.18.0.1", 51234) == {"67890"}
+    assert find_socket_inodes(_PROC_NET_TCP, "172.18.0.1", 51235) == {"67891"}
+    assert find_socket_inodes(_PROC_NET_TCP, "172.18.0.2", 51234) == set()
+
+
+def test_find_socket_inodes_ignores_non_established():
+    # Row 0 is LISTEN (0A) with rem 0.0.0.0:0 — never matched
+    assert find_socket_inodes(_PROC_NET_TCP, "0.0.0.0", 0) == set()
+
+
+def test_candidate_hex_addrs_ipv4_and_mapped():
+    forms = _candidate_hex_addrs("172.18.0.1", 51234)
+    assert "010012AC:C822" in forms  # /proc/net/tcp form
+    # IPv4-mapped IPv6 form for /proc/net/tcp6
+    assert any(len(f.split(":")[0]) == 32 for f in forms)
+
+
+def test_candidate_hex_addrs_ipv6():
+    forms = _candidate_hex_addrs("::1", 22)
+    assert any(len(f.split(":")[0]) == 32 for f in forms)
+
+
+def test_candidate_hex_addrs_invalid_ip_returns_empty():
+    assert _candidate_hex_addrs("not-an-ip", 22) == set()
+    assert _candidate_hex_addrs("", 22) == set()
+    assert find_socket_inodes(_PROC_NET_TCP, "bad.host.name", 51234) == set()

--- a/api/tests/test_session_tracker.py
+++ b/api/tests/test_session_tracker.py
@@ -3,12 +3,11 @@ import asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-import core
-import session_tracker
 from core import hash_password
 from models import AuditAction, AuditLog, Base, SessionTrackerState, SshSession, User, UserRole
 from session_tracker import (
     _candidate_hex_addrs,
+    apply_log_event,
     close_stale_open_sessions,
     find_socket_inodes,
     parse_log_line,
@@ -85,8 +84,8 @@ async def _make_db():
 
 
 def _patch_factory(monkeypatch, factory):
-    monkeypatch.setattr(core, "get_session_factory", lambda: factory)
-    monkeypatch.setattr(session_tracker, "get_session_factory", lambda: factory)
+    monkeypatch.setattr("core.get_session_factory", lambda: factory)
+    monkeypatch.setattr("session_tracker.get_session_factory", lambda: factory)
 
 
 def test_accept_and_close_lifecycle(monkeypatch):
@@ -106,7 +105,7 @@ def test_accept_and_close_lifecycle(monkeypatch):
                 )
                 await db.commit()
 
-            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE))
+            await apply_log_event(parse_log_line(ACCEPT_LINE))
 
             async with factory() as db:
                 sessions = (await db.execute(select(SshSession))).scalars().all()
@@ -120,11 +119,11 @@ def test_accept_and_close_lifecycle(monkeypatch):
                 audit = (await db.execute(select(AuditLog))).scalars().all()
                 assert [a.action for a in audit] == [AuditAction.SESSION_OPENED]
 
-            await session_tracker.apply_log_event(
+            await apply_log_event(
                 parse_log_line("Disconnected from user alice 172.18.0.1 port 51234")
             )
             # A duplicate close line must be a no-op
-            await session_tracker.apply_log_event(
+            await apply_log_event(
                 parse_log_line("Received disconnect from 172.18.0.1 port 51234:11: bye")
             )
 
@@ -148,8 +147,8 @@ def test_accept_is_idempotent_on_replay(monkeypatch):
         _patch_factory(monkeypatch, factory)
         try:
             event = parse_log_line(ACCEPT_LINE)
-            await session_tracker.apply_log_event(event)
-            await session_tracker.apply_log_event(event)
+            await apply_log_event(event)
+            await apply_log_event(event)
 
             async with factory() as db:
                 sessions = (await db.execute(select(SshSession))).scalars().all()
@@ -169,7 +168,7 @@ def test_event_and_position_commit_atomically(monkeypatch):
         engine, factory = await _make_db()
         _patch_factory(monkeypatch, factory)
         try:
-            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
+            await apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
 
             async with factory() as db:
                 state = await db.get(SessionTrackerState, 1)
@@ -177,7 +176,7 @@ def test_event_and_position_commit_atomically(monkeypatch):
 
             # Replaying the same accept (crash before a later offset persisted)
             # is a no-op for rows and audit alike
-            await session_tracker.apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
+            await apply_log_event(parse_log_line(ACCEPT_LINE), position=(7, 123))
             async with factory() as db:
                 assert len((await db.execute(select(SshSession))).scalars().all()) == 1
         finally:
@@ -214,7 +213,7 @@ def test_accept_for_unknown_user_still_recorded(monkeypatch):
         engine, factory = await _make_db()
         _patch_factory(monkeypatch, factory)
         try:
-            await session_tracker.apply_log_event(
+            await apply_log_event(
                 parse_log_line("Accepted publickey for ghost from 10.0.0.9 port 1024 ssh2")
             )
             async with factory() as db:
@@ -232,7 +231,7 @@ def test_close_stale_open_sessions(monkeypatch):
         engine, factory = await _make_db()
         _patch_factory(monkeypatch, factory)
         # No established socket exists for these peers in this test env
-        monkeypatch.setattr(session_tracker, "connection_still_established", lambda ip, port: False)
+        monkeypatch.setattr("session_tracker.connection_still_established", lambda ip, port: False)
         try:
             async with factory() as db:
                 db.add(SshSession(username="alice", source_ip="1.2.3.4", source_port=1))
@@ -265,8 +264,7 @@ def test_close_stale_keeps_live_connections_open(monkeypatch):
         engine, factory = await _make_db()
         _patch_factory(monkeypatch, factory)
         monkeypatch.setattr(
-            session_tracker,
-            "connection_still_established",
+            "session_tracker.connection_still_established",
             lambda ip, port: port == 1,  # only alice's connection is still alive
         )
         try:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,6 +91,8 @@ The application is split across two listeners:
 - `slowapi` — rate limiting
 - `uv` — dependency management (locked via `uv.lock`, installed with `--frozen`)
 
+The api process also runs a **session tracker** (started in the FastAPI lifespan): it tails the sshd log (`/var/log/callis/auth.log`, the same file the fail2ban sidecar reads) and records accepted connections and disconnects as `SshSession` rows with `session_opened`/`session_closed` audit entries. The tracker persists its read position so an API-only restart resumes where it stopped, and the startup sweep only closes records whose connection is no longer established. In the unified container, admins can terminate a session from the web UI — the tracker locates the per-connection sshd child via `/proc/net/tcp{,6}` socket-inode matching and signals it (api and sshd share a PID namespace).
+
 **Directory layout:**
 ```
 api/
@@ -98,10 +100,11 @@ api/
 ├── pyproject.toml
 ├── uv.lock                  # Locked dependency versions (installed with --frozen)
 ├── main.py                  # App factory, mounts /api/v1 routers, middleware
-├── core.py                  # Config, DB session, security utilities
+├── core.py                  # Config, DB session, security utilities, effective-host resolution
 ├── models.py                # All SQLAlchemy models
 ├── schemas.py               # Pydantic response/request schemas for /api/v1
 ├── dependencies.py          # get_current_user, require_role, require_totp
+├── session_tracker.py       # Tails the sshd log into SshSession rows; /proc-based termination
 ├── middleware/
 │   ├── security_headers.py  # CSP, HSTS, X-Frame-Options, etc.
 │   ├── session.py           # JWT cookie validation, session-expiry auditing
@@ -110,8 +113,10 @@ api/
 ├── routers/
 │   ├── auth.py              # /api/v1/auth — login, logout, me, TOTP enrollment
 │   ├── setup.py             # /api/v1/setup — first-run wizard endpoints
-│   ├── users.py             # /api/v1/users — CRUD, roles, key management
+│   ├── users.py             # /api/v1/users — CRUD, roles, key management, recovery codes
 │   ├── hosts.py             # /api/v1/hosts — jump targets, assignments, deploy key
+│   ├── groups.py            # /api/v1/groups — host groups (bulk access assignment)
+│   ├── sessions.py          # /api/v1/sessions — live SSH session view + admin terminate
 │   ├── audit.py             # /api/v1/audit — filterable, paginated log
 │   ├── settings.py          # /api/v1/settings — runtime configuration
 │   ├── dashboard.py         # /api/v1/dashboard — stats + recent activity
@@ -191,6 +196,36 @@ Host
 UserHostAssignment
 ├── user_id (FK → User)
 └── host_id (FK → Host)
+
+HostGroup
+├── id (UUID)
+├── name (unique)
+├── description
+└── created_at
+    (membership via HostGroupHosts [group_id, host_id] and
+     HostGroupUsers [group_id, user_id]; a user's effective host access
+     is direct assignments ∪ group memberships — core.get_effective_hosts,
+     the single source of truth used by the internal API and the web UI)
+
+RecoveryCode
+├── id (UUID)
+├── user_id (FK → User)
+├── code_digest (HMAC-SHA256, keyed by SECRET_KEY)
+├── used_at (null = unused)
+└── created_at
+
+SshSession
+├── id (UUID)
+├── user_id (FK → User, SET NULL on user deletion)
+├── username (denormalized)
+├── source_ip / source_port
+├── key_fingerprint
+├── started_at / ended_at
+└── close_reason (disconnected | terminated | server_restart)
+
+SessionTrackerState (single row)
+├── log_inode / log_offset (BigInteger — resume point in the sshd log)
+└── updated_at
 
 AuditLog
 ├── id (UUID)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -49,7 +49,8 @@ The primary deployment target is homelab and small-team infrastructure environme
 ### 2.4 Host Management
 
 - **FR-HOST-01** — Admins MUST be able to define jump targets (hosts) with: label, hostname/IP, port, and description.
-- **FR-HOST-02** — Hosts MUST be assignable to users, restricting which targets each user may jump to. (Group-based assignment is a planned enhancement.)
+- **FR-HOST-02** — Hosts MUST be assignable to users, restricting which targets each user may jump to.
+- **FR-HOST-05** — Admins MUST be able to define host groups (named sets of hosts) and assign users to groups. A user's effective host access is the union of their direct host assignments and the hosts of every group they belong to. The same effective-access resolution MUST be used by the internal API (permitopen enforcement, tag resolution, host listing) and the web UI.
 - **FR-HOST-03** — The web UI MUST display per-host the SSH client config snippet needed to use Callis as a ProxyJump for that host.
 - **FR-HOST-04** — Hosts MAY be deactivated without deletion.
 
@@ -58,7 +59,8 @@ The primary deployment target is homelab and small-team infrastructure environme
 - **FR-AUTH-01** — All web UI routes MUST require an authenticated session. The only unauthenticated routes are `/login`, `/health`, the CLI installer endpoints (`/install.sh`, `/callis.sh`), and `/setup` (which locks itself down permanently once an admin account exists).
 - **FR-AUTH-02** — Authentication MUST use username and password. Passwords MUST be hashed with bcrypt at cost factor ≥ 12.
 - **FR-AUTH-03** — TOTP (RFC 6238) 2FA MUST be mandatory for all users. A user MUST complete TOTP enrollment before accessing any other page.
-- **FR-AUTH-04** — TOTP enrollment MUST present a QR code and manual secret entry on first login. The TOTP secret MUST be stored encrypted in the database. Backup codes are a future enhancement.
+- **FR-AUTH-04** — TOTP enrollment MUST present a QR code and manual secret entry on first login. The TOTP secret MUST be stored encrypted in the database.
+- **FR-AUTH-11** — On TOTP enrollment, a set of 10 single-use recovery codes MUST be issued and shown exactly once. A recovery code MAY be used in place of a TOTP code at login and is invalidated on use. Codes MUST be stored only as keyed digests (HMAC-SHA256 with `SECRET_KEY`), never in plaintext. Users (and admins acting on any user) MUST be able to regenerate the set, which invalidates all previous codes. Issuance and use MUST be audited.
 - **FR-AUTH-05** — Sessions MUST be stored as JWTs in an `httpOnly`, `Secure`, `SameSite=Strict` cookie. JWTs MUST NOT be returned in response bodies or stored in localStorage.
 - **FR-AUTH-06** — Sessions MUST expire after a configurable idle timeout (default: 30 minutes).
 - **FR-AUTH-07** — Sessions MUST have a configurable absolute maximum lifetime regardless of activity (default: 8 hours).
@@ -82,11 +84,21 @@ The primary deployment target is homelab and small-team infrastructure environme
   - Role changed
   - Host added
   - Host deactivated/deleted
+  - Host group created/deleted, and group host/user membership changes
+  - Recovery codes generated; recovery code used at login
+  - SSH session opened/closed; session terminated by an admin
 - **FR-AUDIT-02** — Audit log entries MUST be append-only. No UI action or API call MUST be able to delete or modify audit log entries.
 - **FR-AUDIT-03** — The audit log MUST be viewable in the web UI with filtering by event type, user, and date range.
 - **FR-AUDIT-04** — Audit logs MUST be persisted across container restarts. They are stored in the database, which lives on the persistent `/data` Docker volume.
 
-### 2.7 Deployment
+### 2.7 Session Visibility
+
+- **FR-SESS-01** — Accepted SSH connections and disconnects MUST be tracked from the sshd log into session records (user, source IP/port, key fingerprint, start/end time) with corresponding audit entries. Pre-auth failures are out of scope (fail2ban's domain).
+- **FR-SESS-02** — The web UI MUST show currently active sessions and recently closed sessions.
+- **FR-SESS-03** — Admins MUST be able to terminate an active session from the web UI (unified container only, where api and sshd share a PID namespace). The record MUST be closed and audited only after the owning process is successfully signalled; if the process cannot be located (e.g. split deployment), the record MUST remain open and the admin informed.
+- **FR-SESS-04** — At startup, session records left open by a previous run MUST be closed (reason `server_restart`, audited) unless their connection is verifiably still established; the tracker MUST resume from its persisted log position so sessions accepted while the API was down are reconciled.
+
+### 2.8 Deployment
 
 - **FR-DEPLOY-01** — The full stack MUST be deployable with a single `docker compose up -d` command. No `.env` file is required for basic operation — `SECRET_KEY` is auto-generated and the admin account is created via the web-based setup wizard on first load.
 - **FR-DEPLOY-02** — The stack MUST work with no domain name on a LAN (accessing the UI via IP and port).

--- a/frontend/src/lib/components/RecoveryCodes.svelte
+++ b/frontend/src/lib/components/RecoveryCodes.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import CopyButton from '$lib/components/CopyButton.svelte';
+
+	let {
+		codes,
+		heading = 'Recovery Codes',
+		continueHref = '/dashboard'
+	}: {
+		codes: string[];
+		heading?: string;
+		continueHref?: string | null;
+	} = $props();
+
+	const text = $derived(codes.join('\n'));
+
+	function download() {
+		const blob = new Blob([text + '\n'], { type: 'text/plain' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'callis-recovery-codes.txt';
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		setTimeout(() => URL.revokeObjectURL(url), 0);
+	}
+</script>
+
+<article class="setup-card">
+	<header>
+		<h2>{heading}</h2>
+		<p>
+			Each code can be used <strong>once</strong> in place of an authenticator code if the
+			authenticator device is lost. Any previously issued codes are now invalid.
+		</p>
+	</header>
+
+	<div class="flash flash-error" role="alert">
+		Save these codes now — they will <strong>never be shown again</strong>.
+	</div>
+
+	<div class="ssh-config-actions">
+		<CopyButton {text} />
+		<button type="button" class="outline btn-sm" onclick={download}>Download</button>
+	</div>
+	<pre class="ssh-config recovery-codes">{text}</pre>
+
+	<p class="text-small text-muted">
+		To use a code, enter it in the "Authenticator Code" field on the login page instead of a
+		6-digit code.
+	</p>
+
+	{#if continueHref}
+		<a href={continueHref} role="button">I have saved my codes — continue</a>
+	{/if}
+</article>

--- a/frontend/src/lib/components/TotpEnroll.svelte
+++ b/frontend/src/lib/components/TotpEnroll.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import type { TOTPSetup } from '$lib/types';
 
 	let {
@@ -36,7 +36,17 @@
 		<pre class="totp-secret">{totp.secret}</pre>
 	</details>
 
-	<form method="post" class="totp-form" use:enhance>
+	<!-- applyAction without invalidation: on success the action returns the
+	     one-time recovery codes, and re-running this page's load would
+	     redirect (already enrolled) and lose them. -->
+	<form
+		method="post"
+		class="totp-form"
+		use:enhance={() =>
+			async ({ result }) => {
+				await applyAction(result);
+			}}
+	>
 		<label for="totp_code">Enter 6-digit code from your authenticator</label>
 		<input
 			type="text"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -74,10 +74,51 @@ export interface Meta {
 	setup_needed: boolean;
 }
 
+export interface HostRef {
+	id: string;
+	label: string;
+}
+
+export interface GroupRef {
+	id: string;
+	name: string;
+}
+
+export interface Group {
+	id: string;
+	name: string;
+	description: string | null;
+	created_at: string;
+	hosts: HostRef[];
+	users: UserRef[];
+}
+
+export interface SshSession {
+	id: string;
+	username: string;
+	source_ip: string;
+	source_port: number;
+	key_fingerprint: string | null;
+	started_at: string;
+	ended_at: string | null;
+	close_reason: string | null;
+}
+
+export interface Sessions {
+	active: SshSession[];
+	recent: SshSession[];
+}
+
+export interface RecoveryCodes {
+	codes: string[];
+}
+
 export interface UserDetail {
 	user: User;
 	keys: SSHKey[];
 	assigned_hosts: Host[];
+	host_groups: GroupRef[];
+	recovery_codes_remaining: number;
 	ssh_host: string;
 	ssh_port: number;
 	roles: string[];
@@ -86,6 +127,7 @@ export interface UserDetail {
 export interface Dashboard {
 	active_users: number;
 	active_hosts: number;
+	active_sessions: number;
 	user_key_count: number;
 	recent_audit: AuditEntry[];
 	ssh_host: string;
@@ -117,4 +159,9 @@ export interface TOTPSetup {
 
 export interface Session {
 	user: User;
+}
+
+export interface Enroll extends Session {
+	/** One-time 2FA recovery codes, returned exactly once at enrollment. */
+	recovery_codes: string[];
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -29,6 +29,7 @@
 				{/if}
 				<li><a href="/users/{user.id}">My Profile</a></li>
 				<li><a href="/hosts">Hosts</a></li>
+				<li><a href="/sessions">Sessions</a></li>
 				<li><a href="/audit">Audit Log</a></li>
 				{#if user.role === 'admin'}
 					<li><a href="/settings">Settings</a></li>

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -26,6 +26,10 @@
 		<p class="stat-value">{d.active_hosts}</p>
 	</article>
 	<article>
+		<header><a href="/sessions">Active Sessions</a></header>
+		<p class="stat-value">{d.active_sessions}</p>
+	</article>
+	<article>
 		<header>Your Keys</header>
 		<p class="stat-value">{d.user_key_count}</p>
 	</article>

--- a/frontend/src/routes/hosts/+page.server.ts
+++ b/frontend/src/routes/hosts/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { apiAttempt, apiFetch, apiJson } from '$lib/server/api';
-import type { Host, UserListItem } from '$lib/types';
+import type { Group, Host, UserListItem } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 interface DeployKey {
@@ -9,7 +9,10 @@ interface DeployKey {
 
 export const load: PageServerLoad = async (event) => {
 	const { user } = await event.parent();
-	const hosts = await apiJson<Host[]>(event, '/api/v1/hosts');
+	const [hosts, groups] = await Promise.all([
+		apiJson<Host[]>(event, '/api/v1/hosts'),
+		apiJson<Group[]>(event, '/api/v1/groups')
+	]);
 
 	// Admin-only extras: assignable users + the server deploy key. Fetched
 	// concurrently; non-admins never trigger these requests.
@@ -32,7 +35,7 @@ export const load: PageServerLoad = async (event) => {
 		}
 	}
 
-	return { hosts, allUsers, deployKey, title: 'Hosts' };
+	return { hosts, groups, allUsers, deployKey, title: 'Hosts' };
 };
 
 export const actions: Actions = {
@@ -93,6 +96,78 @@ export const actions: Actions = {
 			event,
 			`/api/v1/hosts/${encodeURIComponent(id)}/unassign/${encodeURIComponent(userId)}`,
 			{ method: 'POST' }
+		);
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		return {};
+	},
+	createGroup: async (event) => {
+		const form = await event.request.formData();
+		const name = String(form.get('name') ?? '');
+		const description = String(form.get('description') ?? '');
+		const result = await apiAttempt(event, '/api/v1/groups', {
+			method: 'POST',
+			body: { name, description }
+		});
+		if (!result.ok) {
+			return fail(result.status, { error: result.detail, groupValues: { name, description } });
+		}
+		return { groupCreated: true };
+	},
+	deleteGroup: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const result = await apiAttempt(event, `/api/v1/groups/${encodeURIComponent(id)}`, {
+			method: 'DELETE'
+		});
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		return {};
+	},
+	groupAddHost: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const hostId = String(form.get('host_id') ?? '');
+		if (!hostId) return {};
+		const result = await apiAttempt(
+			event,
+			`/api/v1/groups/${encodeURIComponent(id)}/hosts/${encodeURIComponent(hostId)}`,
+			{ method: 'POST' }
+		);
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		return {};
+	},
+	groupRemoveHost: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const hostId = String(form.get('host_id') ?? '');
+		const result = await apiAttempt(
+			event,
+			`/api/v1/groups/${encodeURIComponent(id)}/hosts/${encodeURIComponent(hostId)}`,
+			{ method: 'DELETE' }
+		);
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		return {};
+	},
+	groupAddUser: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const userId = String(form.get('target_user_id') ?? '');
+		if (!userId) return {};
+		const result = await apiAttempt(
+			event,
+			`/api/v1/groups/${encodeURIComponent(id)}/users/${encodeURIComponent(userId)}`,
+			{ method: 'POST' }
+		);
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		return {};
+	},
+	groupRemoveUser: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const userId = String(form.get('target_user_id') ?? '');
+		const result = await apiAttempt(
+			event,
+			`/api/v1/groups/${encodeURIComponent(id)}/users/${encodeURIComponent(userId)}`,
+			{ method: 'DELETE' }
 		);
 		if (!result.ok) return fail(result.status, { error: result.detail });
 		return {};

--- a/frontend/src/routes/hosts/+page.svelte
+++ b/frontend/src/routes/hosts/+page.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/state';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Dialog from '$lib/components/Dialog.svelte';
-	import type { Host } from '$lib/types';
+	import type { Group, Host } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -13,12 +13,16 @@
 	const isAdmin = $derived(me.role === 'admin');
 	const errorMsg = $derived(form && 'error' in form && form.error ? form.error : null);
 	const createFailed = $derived(!!(form && 'values' in form && form.values));
+	const groupCreateFailed = $derived(!!(form && 'groupValues' in form && form.groupValues));
 
 	let addHostOpen = $state(false);
+	let addGroupOpen = $state(false);
 
 	$effect(() => {
 		if (form && 'values' in form && form.values) addHostOpen = true;
 		if (form && 'created' in form && form.created) addHostOpen = false;
+		if (form && 'groupValues' in form && form.groupValues) addGroupOpen = true;
+		if (form && 'groupCreated' in form && form.groupCreated) addGroupOpen = false;
 	});
 
 	function sshConfigBlock(host: Host): string {
@@ -28,6 +32,16 @@
 	function assignableUsers(host: Host) {
 		const assigned = new Set(host.assigned_users.map((u) => u.id));
 		return data.allUsers.filter((u) => !assigned.has(u.id));
+	}
+
+	function groupAssignableHosts(group: Group) {
+		const members = new Set(group.hosts.map((h) => h.id));
+		return data.hosts.filter((h) => h.is_active && !members.has(h.id));
+	}
+
+	function groupAssignableUsers(group: Group) {
+		const members = new Set(group.users.map((u) => u.id));
+		return data.allUsers.filter((u) => !members.has(u.id));
 	}
 
 	function autoSubmit(event: Event) {
@@ -49,7 +63,7 @@
 	config and with <code>ssh callis resolve &lt;alias&gt;</code>.
 </p>
 
-{#if errorMsg && !createFailed}
+{#if errorMsg && !createFailed && !groupCreateFailed}
 	<div class="flash flash-error" role="alert">{errorMsg}</div>
 {/if}
 
@@ -226,6 +240,202 @@
 		{:else}
 			Ask an administrator to add hosts and assign you to them.
 		{/if}
+	</p>
+{/if}
+
+<hr />
+<div class="page-header">
+	<h3>Host Groups</h3>
+	{#if isAdmin}
+		<button onclick={() => (addGroupOpen = true)}>Add Group</button>
+	{/if}
+</div>
+
+<p class="text-muted">
+	Groups bundle hosts so access can be granted as a unit. A user's effective access is their
+	direct host assignments <strong>plus</strong> the hosts of every group they belong to.
+</p>
+
+{#if isAdmin}
+	<Dialog title="Add Host Group" bind:open={addGroupOpen}>
+		{#if errorMsg && groupCreateFailed}
+			<div class="flash flash-error" role="alert">{errorMsg}</div>
+		{/if}
+		<form method="post" action="?/createGroup" use:enhance>
+			<label for="group-name">Name</label>
+			<input
+				type="text"
+				id="group-name"
+				name="name"
+				required
+				placeholder="e.g. Production"
+				value={(form && 'groupValues' in form && form.groupValues?.name) || ''}
+				aria-describedby="group_name_help"
+			/>
+			<p id="group_name_help" class="helper-text">A unique name for this group of hosts.</p>
+
+			<label for="group-description">Description</label>
+			<textarea
+				id="group-description"
+				name="description"
+				rows="2"
+				placeholder="Optional — what these hosts have in common"
+				value={(form && 'groupValues' in form && form.groupValues?.description) || ''}
+			></textarea>
+
+			<button type="submit">Add Group</button>
+		</form>
+	</Dialog>
+{/if}
+
+{#if data.groups.length > 0}
+	<figure>
+		<table>
+			<thead>
+				<tr>
+					<th>Group</th>
+					<th>Hosts</th>
+					<th>Members</th>
+					{#if isAdmin}
+						<th>Actions</th>
+					{/if}
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.groups as group (group.id)}
+					<tr>
+						<td>
+							<strong>{group.name}</strong>
+							{#if group.description}
+								<br /><span class="text-small text-muted">{group.description}</span>
+							{/if}
+						</td>
+						<td>
+							{#each group.hosts as h (h.id)}
+								<span class="badge">
+									{h.label}
+									{#if isAdmin}
+										<form
+											method="post"
+											action="?/groupRemoveHost"
+											class="assign-form"
+											use:enhance={({ cancel }) => {
+												if (!window.confirm(`Remove host ${h.label} from ${group.name}?`)) cancel();
+											}}
+										>
+											<input type="hidden" name="id" value={group.id} />
+											<input type="hidden" name="host_id" value={h.id} />
+											<button
+												type="submit"
+												class="unassign-btn"
+												aria-label="Remove {h.label} from {group.name}"
+											>
+												&times;
+											</button>
+										</form>
+									{/if}
+								</span>
+							{:else}
+								<span class="text-muted text-small">None</span>
+							{/each}
+							{#if isAdmin && groupAssignableHosts(group).length > 0}
+								<form method="post" action="?/groupAddHost" class="assign-form" use:enhance>
+									<input type="hidden" name="id" value={group.id} />
+									<select
+										name="host_id"
+										class="assign-select"
+										aria-label="Add host to {group.name}"
+										onchange={autoSubmit}
+									>
+										<option value="">+ Host</option>
+										{#each groupAssignableHosts(group) as h (h.id)}
+											<option value={h.id}>{h.label}</option>
+										{/each}
+									</select>
+									<noscript><button type="submit" class="assign-go outline">Go</button></noscript>
+								</form>
+							{/if}
+						</td>
+						<td>
+							{#each group.users as u (u.id)}
+								<span class="badge">
+									{u.username}
+									{#if isAdmin}
+										<form
+											method="post"
+											action="?/groupRemoveUser"
+											class="assign-form"
+											use:enhance={({ cancel }) => {
+												if (
+													!window.confirm(
+														`Remove ${u.username} from ${group.name}? They will lose access to this group's hosts.`
+													)
+												)
+													cancel();
+											}}
+										>
+											<input type="hidden" name="id" value={group.id} />
+											<input type="hidden" name="target_user_id" value={u.id} />
+											<button
+												type="submit"
+												class="unassign-btn"
+												aria-label="Remove {u.username} from {group.name}"
+											>
+												&times;
+											</button>
+										</form>
+									{/if}
+								</span>
+							{:else}
+								<span class="text-muted text-small">None</span>
+							{/each}
+							{#if isAdmin && groupAssignableUsers(group).length > 0}
+								<form method="post" action="?/groupAddUser" class="assign-form" use:enhance>
+									<input type="hidden" name="id" value={group.id} />
+									<select
+										name="target_user_id"
+										class="assign-select"
+										aria-label="Add user to {group.name}"
+										onchange={autoSubmit}
+									>
+										<option value="">+ User</option>
+										{#each groupAssignableUsers(group) as u (u.id)}
+											<option value={u.id}>{u.username}</option>
+										{/each}
+									</select>
+									<noscript><button type="submit" class="assign-go outline">Go</button></noscript>
+								</form>
+							{/if}
+						</td>
+						{#if isAdmin}
+							<td class="actions">
+								<form
+									method="post"
+									action="?/deleteGroup"
+									use:enhance={({ cancel }) => {
+										if (
+											!window.confirm(
+												`Delete group ${group.name}? Members lose any host access granted only through this group.`
+											)
+										)
+											cancel();
+									}}
+								>
+									<input type="hidden" name="id" value={group.id} />
+									<button type="submit" class="outline contrast">Delete</button>
+								</form>
+							</td>
+						{/if}
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</figure>
+{:else}
+	<p class="text-muted">
+		No host groups yet.{#if isAdmin}
+			Click <strong>Add Group</strong> to create one, then add hosts and members to grant access
+			in bulk.{/if}
 	</p>
 {/if}
 

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -39,14 +39,13 @@
 			name="totp_code"
 			autocomplete="one-time-code"
 			placeholder="6-digit code"
-			inputmode="numeric"
-			pattern="[0-9]{'{'}6{'}'}"
-			maxlength="6"
+			pattern="[0-9]{'{'}6{'}'}|[A-Za-z0-9 \-]{'{'}10,14{'}'}"
+			maxlength="14"
 			aria-describedby="totp_code_help"
 		/>
 		<p id="totp_code_help" class="helper-text">
-			Enter the code from your authenticator app. Leave blank on your first login &mdash; you
-			will set up two-factor authentication next.
+			Enter the code from your authenticator app, or a recovery code if you lost your device.
+			Leave blank on your first login &mdash; you will set up two-factor authentication next.
 		</p>
 
 		<button type="submit">Sign In</button>

--- a/frontend/src/routes/sessions/+page.server.ts
+++ b/frontend/src/routes/sessions/+page.server.ts
@@ -1,0 +1,31 @@
+import { fail } from '@sveltejs/kit';
+import { apiAttempt, apiJson } from '$lib/server/api';
+import type { Sessions } from '$lib/types';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async (event) => {
+	const sessions = await apiJson<Sessions>(event, '/api/v1/sessions');
+	return { sessions, title: 'Sessions' };
+};
+
+export const actions: Actions = {
+	terminate: async (event) => {
+		const form = await event.request.formData();
+		const id = String(form.get('id') ?? '');
+		const result = await apiAttempt(
+			event,
+			`/api/v1/sessions/${encodeURIComponent(id)}/terminate`,
+			{ method: 'POST' }
+		);
+		if (!result.ok) {
+			const detail =
+				result.detail === 'session_process_not_found'
+					? 'Could not locate the session process. The record was left open — ' +
+						'in-container termination requires the unified deployment; the session ' +
+						'will close when it disconnects.'
+					: result.detail;
+			return fail(result.status, { error: detail });
+		}
+		return {};
+	}
+};

--- a/frontend/src/routes/sessions/+page.svelte
+++ b/frontend/src/routes/sessions/+page.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import { page } from '$app/state';
+	import { formatDateTime } from '$lib/format';
+	import type { ActionData, PageData } from './$types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	const me = $derived(page.data.user!);
+	const isAdmin = $derived(me.role === 'admin');
+	const errorMsg = $derived(form && 'error' in form && form.error ? form.error : null);
+
+	// Live view: refresh the session tables every 10 seconds.
+	onMount(() => {
+		const timer = setInterval(() => invalidateAll(), 10_000);
+		return () => clearInterval(timer);
+	});
+</script>
+
+<h2>SSH Sessions</h2>
+
+<p class="text-muted">
+	Live view of connections through the bastion, tracked from the sshd log. The tables refresh
+	automatically every 10 seconds.
+</p>
+
+{#if errorMsg}
+	<div class="flash flash-error" role="alert">{errorMsg}</div>
+{/if}
+
+<h3>Active <span class="badge badge-active">{data.sessions.active.length}</span></h3>
+{#if data.sessions.active.length > 0}
+	<figure>
+		<table>
+			<thead>
+				<tr>
+					<th>User</th>
+					<th>Source</th>
+					<th>Connected Since</th>
+					<th>Key Fingerprint</th>
+					{#if isAdmin}
+						<th>Actions</th>
+					{/if}
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.sessions.active as s (s.id)}
+					<tr>
+						<td>{s.username}</td>
+						<td><code class="text-small">{s.source_ip}:{s.source_port}</code></td>
+						<td class="text-small">{formatDateTime(s.started_at)}</td>
+						<td><code class="text-small">{s.key_fingerprint ?? '—'}</code></td>
+						{#if isAdmin}
+							<td>
+								<form
+									method="post"
+									action="?/terminate"
+									use:enhance={({ cancel }) => {
+										if (
+											!window.confirm(
+												`Terminate this SSH session for ${s.username}? The connection will be dropped immediately.`
+											)
+										)
+											cancel();
+									}}
+								>
+									<input type="hidden" name="id" value={s.id} />
+									<button type="submit" class="outline contrast btn-sm">Terminate</button>
+								</form>
+							</td>
+						{/if}
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</figure>
+{:else}
+	<p class="text-muted">No active SSH sessions.</p>
+{/if}
+
+<h3>Recently Closed</h3>
+{#if data.sessions.recent.length > 0}
+	<figure>
+		<table>
+			<thead>
+				<tr>
+					<th>User</th>
+					<th>Source</th>
+					<th>Connected</th>
+					<th>Disconnected</th>
+					<th>Reason</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.sessions.recent as s (s.id)}
+					<tr>
+						<td>{s.username}</td>
+						<td><code class="text-small">{s.source_ip}:{s.source_port}</code></td>
+						<td class="text-small">{formatDateTime(s.started_at)}</td>
+						<td class="text-small">{s.ended_at ? formatDateTime(s.ended_at) : '—'}</td>
+						<td>
+							<span class="badge {s.close_reason === 'terminated' ? 'badge-inactive' : ''}">
+								{(s.close_reason ?? 'disconnected').replace('_', ' ')}
+							</span>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</figure>
+{:else}
+	<p class="text-muted">
+		No closed sessions recorded yet. Sessions appear here once users connect through the bastion.
+	</p>
+{/if}

--- a/frontend/src/routes/setup/totp/+page.server.ts
+++ b/frontend/src/routes/setup/totp/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { apiAttempt, apiFetch } from '$lib/server/api';
-import type { Session, TOTPSetup } from '$lib/types';
+import type { Enroll, TOTPSetup } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
@@ -16,7 +16,7 @@ export const load: PageServerLoad = async (event) => {
 export const actions: Actions = {
 	default: async (event) => {
 		const form = await event.request.formData();
-		const result = await apiAttempt<Session>(event, '/api/v1/setup/totp/verify', {
+		const result = await apiAttempt<Enroll>(event, '/api/v1/setup/totp/verify', {
 			method: 'POST',
 			body: { totp_code: String(form.get('totp_code') ?? '') }
 		});
@@ -24,6 +24,8 @@ export const actions: Actions = {
 			if (result.status === 409) redirect(303, '/dashboard');
 			return fail(result.status, { error: result.detail });
 		}
-		redirect(303, '/dashboard');
+		// Show the one-time recovery codes before continuing to the dashboard.
+		event.setHeaders({ 'cache-control': 'no-store' });
+		return { recoveryCodes: result.data.recovery_codes };
 	}
 };

--- a/frontend/src/routes/setup/totp/+page.svelte
+++ b/frontend/src/routes/setup/totp/+page.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
+	import RecoveryCodes from '$lib/components/RecoveryCodes.svelte';
 	import TotpEnroll from '$lib/components/TotpEnroll.svelte';
 	import type { ActionData, PageData } from './$types';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	const recoveryCodes = $derived(
+		form && 'recoveryCodes' in form ? (form.recoveryCodes ?? null) : null
+	);
 </script>
 
-<TotpEnroll totp={data.totp} buttonLabel="Verify & Complete Setup" error={form?.error ?? null} />
+{#if recoveryCodes}
+	<RecoveryCodes codes={recoveryCodes} />
+{:else}
+	<TotpEnroll
+		totp={data.totp}
+		buttonLabel="Verify & Complete Setup"
+		error={form && 'error' in form ? (form.error ?? null) : null}
+	/>
+{/if}

--- a/frontend/src/routes/totp/setup/+page.server.ts
+++ b/frontend/src/routes/totp/setup/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { apiAttempt, apiFetch } from '$lib/server/api';
-import type { Session, TOTPSetup } from '$lib/types';
+import type { Enroll, TOTPSetup } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async (event) => {
 export const actions: Actions = {
 	default: async (event) => {
 		const form = await event.request.formData();
-		const result = await apiAttempt<Session>(event, '/api/v1/auth/totp/verify', {
+		const result = await apiAttempt<Enroll>(event, '/api/v1/auth/totp/verify', {
 			method: 'POST',
 			body: { totp_code: String(form.get('totp_code') ?? '') }
 		});
@@ -23,6 +23,8 @@ export const actions: Actions = {
 			if (result.status === 409) redirect(303, '/dashboard');
 			return fail(result.status, { error: result.detail });
 		}
-		redirect(303, '/dashboard');
+		// Show the one-time recovery codes before continuing to the dashboard.
+		event.setHeaders({ 'cache-control': 'no-store' });
+		return { recoveryCodes: result.data.recovery_codes };
 	}
 };

--- a/frontend/src/routes/totp/setup/+page.svelte
+++ b/frontend/src/routes/totp/setup/+page.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
+	import RecoveryCodes from '$lib/components/RecoveryCodes.svelte';
 	import TotpEnroll from '$lib/components/TotpEnroll.svelte';
 	import type { ActionData, PageData } from './$types';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	const recoveryCodes = $derived(
+		form && 'recoveryCodes' in form ? (form.recoveryCodes ?? null) : null
+	);
 </script>
 
-<TotpEnroll totp={data.totp} error={form?.error ?? null} />
+{#if recoveryCodes}
+	<RecoveryCodes codes={recoveryCodes} />
+{:else}
+	<TotpEnroll totp={data.totp} error={form && 'error' in form ? (form.error ?? null) : null} />
+{/if}

--- a/frontend/src/routes/users/[id]/+page.server.ts
+++ b/frontend/src/routes/users/[id]/+page.server.ts
@@ -67,5 +67,17 @@ export const actions: Actions = {
 		);
 		if (!result.ok) return fail(result.status, { error: result.detail });
 		return {};
+	},
+	regenerateRecoveryCodes: async (event) => {
+		const result = await apiAttempt<{ codes: string[] }>(
+			event,
+			`/api/v1/users/${encodeURIComponent(event.params.id)}/recovery-codes`,
+			{ method: 'POST' }
+		);
+		if (!result.ok) return fail(result.status, { error: result.detail });
+		// The codes exist only in this one response — never persisted in
+		// plaintext server-side and gone when the page re-renders.
+		event.setHeaders({ 'cache-control': 'no-store' });
+		return { recoveryCodes: result.data.codes };
 	}
 };

--- a/frontend/src/routes/users/[id]/+page.svelte
+++ b/frontend/src/routes/users/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Dialog from '$lib/components/Dialog.svelte';
+	import RecoveryCodes from '$lib/components/RecoveryCodes.svelte';
 	import SshConfigSection from '$lib/components/SshConfigSection.svelte';
 	import { formatDate, formatDateTime } from '$lib/format';
 	import type { ActionData, PageData } from './$types';
@@ -12,6 +13,12 @@
 	const me = $derived(page.data.user!);
 	const target = $derived(data.detail.user);
 	const generated = $derived(form && 'generated' in form ? form.generated : null);
+	const regeneratedCodes = $derived(
+		form && 'recoveryCodes' in form ? (form.recoveryCodes ?? null) : null
+	);
+	const canManageRecoveryCodes = $derived(
+		target.is_active && target.totp_enrolled && (me.role === 'admin' || me.id === target.id)
+	);
 
 	let generateOpen = $state(false);
 
@@ -74,6 +81,42 @@
 			</dd>
 			<dt>Authenticator App</dt>
 			<dd>{target.totp_enrolled ? 'Enrolled' : 'Not enrolled'}</dd>
+			{#if target.totp_enrolled}
+				<dt>Recovery Codes</dt>
+				<dd>
+					{data.detail.recovery_codes_remaining} unused
+					{#if canManageRecoveryCodes}
+						<form
+							method="post"
+							action="?/regenerateRecoveryCodes"
+							class="role-change-form"
+							use:enhance={({ cancel }) => {
+								if (
+									!window.confirm(
+										'Generate new recovery codes? All existing codes will stop working immediately.'
+									)
+								)
+									cancel();
+							}}
+						>
+							<button type="submit" class="outline btn-sm">Regenerate</button>
+						</form>
+					{/if}
+				</dd>
+			{/if}
+			<dt>Host Groups</dt>
+			<dd>
+				{#each data.detail.host_groups as g (g.id)}
+					<span class="badge">{g.name}</span>
+				{:else}
+					<span class="text-muted">None</span>
+				{/each}
+				{#if me.role === 'admin'}
+					<br /><span class="text-small text-muted">
+						Manage group membership on the <a href="/hosts">Hosts</a> page.
+					</span>
+				{/if}
+			</dd>
 			<dt>Created</dt>
 			<dd>{formatDateTime(target.created_at)}</dd>
 			<dt>Last Login</dt>
@@ -81,6 +124,16 @@
 		</dl>
 	</div>
 </div>
+
+{#if regeneratedCodes}
+	<RecoveryCodes
+		codes={regeneratedCodes}
+		heading={me.id === target.id
+			? 'Your New Recovery Codes'
+			: `New Recovery Codes for ${target.username}`}
+		continueHref={null}
+	/>
+{/if}
 
 <hr />
 


### PR DESCRIPTION
Implements the three features proposed and approved in planning: TOTP recovery codes, live session visibility, and host groups. **Rebased onto the SvelteKit migration (#34)**: backend surface is expressed as `/api/v1` JSON endpoints and the UI is implemented in the SvelteKit SSR frontend. All schema changes are additive (new tables only), so existing deployments upgrade without migration — plus an idempotent startup `ALTER TYPE ... ADD VALUE` for the PostgreSQL audit enum.

## 1. Single-use 2FA recovery codes

TOTP is mandatory for every web UI user, so a lost authenticator device previously meant admin intervention — or database surgery for a sole admin.

- 10 single-use codes issued at TOTP enrollment (setup wizard and regular flow); `/api/v1/{auth,setup}/totp/verify` returns them exactly once and the frontend shows them with copy/download before continuing
- A recovery code can be entered in the Authenticator Code field at login; consumption is atomic (conditional `UPDATE ... WHERE used_at IS NULL`) so concurrent logins cannot double-spend a code, and is audited with the remaining count
- Codes stored only as HMAC-SHA256 digests keyed by `SECRET_KEY` (high-entropy random codes → fast keyed hash is appropriate and allows indexed lookup; passwords still use bcrypt)
- `POST /api/v1/users/{id}/recovery-codes` regenerates the set (admin or self), invalidating all previous codes; the profile page shows the unused count

## 2. Live SSH session visibility with admin termination

Closes the audit gap where connection tracking ended at key-offer time (`internal.py` documents that `KEY_USED` fires pre-auth).

- New `session_tracker.py` tails the sshd log (`sshd -E`, the same file the fail2ban sidecar reads) and records accepts/disconnects as `SshSession` rows plus `session_opened`/`session_closed` audit entries; pre-auth lines are ignored
- The tracker persists its read position (inode + offset, `BigInteger`) and resumes after an API-only restart, reconciling sessions accepted while the API was down; accept handling is idempotent so replay cannot duplicate rows
- The startup sweep closes stale records (audited, reason `server_restart`) only when no established socket to the peer remains — supervisord restarts api and sshd independently, so live connections stay visible
- `/sessions` page shows active and recently closed sessions with a 10s auto-refresh; dashboard gains an Active Sessions stat
- Admins can terminate a session: the owning sshd child is located via `/proc/net/tcp{,6}` socket-inode matching (unified container shares a PID namespace) and SIGTERMed. The record is closed and audited **only after a successful signal**; otherwise it stays open and the admin is told why (split deployments cannot see sshd's PID namespace)

## 3. Host groups (group-based access assignment)

The planned enhancement from FR-HOST-02: onboarding no longer requires per-user × per-host clicks.

- `HostGroup` with host and user membership; effective access = direct assignments ∪ group memberships
- Resolution centralized in `core.get_effective_hosts`, used by **all three** internal endpoints (`permitopen` construction, tag resolve, host list) and the profile page's generated SSH config — one source of truth, so the UI and sshd enforcement can never disagree
- `/api/v1/groups` CRUD + membership endpoints; Hosts page gains a Host Groups section with the same select-to-assign UX as host assignment; all changes audited

## Review feedback incorporated

All findings from the Gemini and Codex review rounds on the pre-rebase branch are carried into the port: log-read error recovery and event-loop yielding in the follower, invalid-IP tolerance in `/proc` matching, atomic recovery-code consumption, all-digit recovery codes accepted, PG enum migration using member names, `BigInteger` tracker state, audited stale closures, explicit `SET NULL` for session history on user deletion, downtime-window reconciliation, and no-close-without-signal termination.

## Tests

- `uv run pytest`: **63 passed** — unit coverage for code generation/hashing/consumption, sshd log parsing, session lifecycle/stale cleanup, `/proc/net/tcp` peer matching, and effective-host resolution, plus end-to-end `/api/v1` tests for all three flows (recovery login round-trip, group membership → effective access, session listing and honest terminate failure)
- `svelte-check`: 0 errors; production build passes

Docs updated: REQUIREMENTS (FR-AUTH-11, FR-HOST-05, FR-SESS-01…04, audit event list), ARCHITECTURE (data model, layout, session tracker), README feature list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y23LZbxMCY2EFJNwDvyGU7