### PR TITLE
Harden access control, sessions, TOTP, and reverse-proxy trust

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,13 +40,17 @@
 # Set to true to enable HSTS and Secure cookie flag
 # HTTPS_ENABLED=false
 
-# Comma-separated list of trusted reverse-proxy addresses (IPs or CIDRs)
-# for X-Forwarded-For/Proto processing. REQUIRED when HTTPS_ENABLED=true:
-# set it to your reverse proxy's IP(s)/CIDR(s). A wildcard "*" (or an empty
-# value) is refused when HTTPS_ENABLED=true because it would let any client
-# spoof X-Forwarded-For, forging audit source IPs and bypassing rate limiting.
-# Ignored in the default LAN/HTTP mode (only loopback is trusted).
-# TRUSTED_PROXIES=10.0.0.0/24
+# Trusted reverse-proxy addresses (IPs or CIDRs) allowed to set X-Forwarded-*.
+# REQUIRED when HTTPS_ENABLED=true. Set it to the address Callis SEES the proxy
+# connect from — NOT the proxy's public address, and usually NOT 127.0.0.1. For
+# Docker this is the proxy's network subnet or the bridge gateway; the most
+# reliable setup is to run the proxy on the same Docker network with the web
+# port unpublished and use that network's subnet (docker network inspect).
+# Unsure? Attempt a login through the proxy and read source_ip from the audit
+# log — that is the value to use. A wildcard "*" or catch-all (0.0.0.0/0, ::/0)
+# is refused at startup. Ignored in LAN/HTTP mode (only loopback is trusted).
+# See the README "Choosing TRUSTED_PROXIES" section for full guidance.
+# TRUSTED_PROXIES=172.18.0.0/16
 
 # Development mode — enables verbose SQL logging
 # Cookie Secure flag is controlled by HTTPS_ENABLED, not DEV_MODE

--- a/.env.example
+++ b/.env.example
@@ -41,9 +41,12 @@
 # HTTPS_ENABLED=false
 
 # Comma-separated list of trusted reverse-proxy addresses (IPs or CIDRs)
-# for X-Forwarded-Proto/Host processing. Only used when HTTPS_ENABLED=true.
-# Default "*" trusts all; set to your proxy IP(s) for stricter hardening.
-# TRUSTED_PROXIES=*
+# for X-Forwarded-For/Proto processing. REQUIRED when HTTPS_ENABLED=true:
+# set it to your reverse proxy's IP(s)/CIDR(s). A wildcard "*" (or an empty
+# value) is refused when HTTPS_ENABLED=true because it would let any client
+# spoof X-Forwarded-For, forging audit source IPs and bypassing rate limiting.
+# Ignored in the default LAN/HTTP mode (only loopback is trusted).
+# TRUSTED_PROXIES=10.0.0.0/24
 
 # Development mode — enables verbose SQL logging
 # Cookie Secure flag is controlled by HTTPS_ENABLED, not DEV_MODE

--- a/README.md
+++ b/README.md
@@ -134,9 +134,16 @@ Callis serves plain HTTP on port 8080. TLS termination is handled by your revers
 ```bash
 BASE_URL=https://callis.example.com
 HTTPS_ENABLED=true
+# Required with HTTPS_ENABLED — the IP/CIDR your reverse proxy connects FROM.
+# Use 127.0.0.1 when the proxy runs on the same host and dials localhost:8080
+# (the common Caddy/Nginx setup); use the proxy container's network address if
+# it reaches Callis over a Docker/other network.
+TRUSTED_PROXIES=127.0.0.1
 ```
 
 `HTTPS_ENABLED=true` enables HSTS headers and sets the `Secure` flag on session cookies (required when serving over HTTPS).
+
+`TRUSTED_PROXIES` must name your reverse proxy's address so only it can supply `X-Forwarded-For`. A wildcard `*` or catch-all network (`0.0.0.0/0`) is refused at startup, because trusting it would let any client spoof their source IP — forging audit-log entries and bypassing login rate limiting.
 
 **2. Point your reverse proxy at Callis port 8080:**
 

--- a/README.md
+++ b/README.md
@@ -134,16 +134,21 @@ Callis serves plain HTTP on port 8080. TLS termination is handled by your revers
 ```bash
 BASE_URL=https://callis.example.com
 HTTPS_ENABLED=true
-# Required with HTTPS_ENABLED — the IP/CIDR your reverse proxy connects FROM.
-# Use 127.0.0.1 when the proxy runs on the same host and dials localhost:8080
-# (the common Caddy/Nginx setup); use the proxy container's network address if
-# it reaches Callis over a Docker/other network.
-TRUSTED_PROXIES=127.0.0.1
+# Required with HTTPS_ENABLED. Set it to the address Callis SEES your reverse
+# proxy connect from — not the proxy's public address. See "Choosing
+# TRUSTED_PROXIES" below; this example fits the recommended Docker-network setup.
+TRUSTED_PROXIES=172.18.0.0/16
 ```
 
 `HTTPS_ENABLED=true` enables HSTS headers and sets the `Secure` flag on session cookies (required when serving over HTTPS).
 
-`TRUSTED_PROXIES` must name your reverse proxy's address so only it can supply `X-Forwarded-For`. A wildcard `*` or catch-all network (`0.0.0.0/0`) is refused at startup, because trusting it would let any client spoof their source IP — forging audit-log entries and bypassing login rate limiting.
+**Choosing `TRUSTED_PROXIES`.** Only the peer named here may supply `X-Forwarded-For` (the real client IP used for audit logging and login rate limiting); every other client's forwarded headers are ignored. It must be the address Callis *observes the proxy connecting from*, which is usually **not** `127.0.0.1`:
+
+- **Recommended — proxy on the same Docker network, web port not published.** Run your reverse proxy as a service alongside Callis and remove the `8080` port mapping from `docker-compose.yml` so the web UI is reachable *only* through the proxy. Callis then sees the proxy connect from its container address; set `TRUSTED_PROXIES` to that Docker network's subnet (find it with `docker network inspect <network>` → `Subnet`, e.g. `172.18.0.0/16`). This is the only topology where Callis can reliably tell your proxy apart from a direct client.
+- **Host-based proxy (Caddy/Nginx on the host) dialing a published `8080`.** Callis sees these connections from the Docker bridge gateway (e.g. `172.17.0.1`), not `127.0.0.1` — set `TRUSTED_PROXIES` to that gateway. **Caveat:** because the port is published, a client that reaches `8080` directly *also* appears as the gateway, so Callis cannot distinguish it from your proxy. Restrict the published port to the proxy host (firewall it, or bind it to a private interface) or use the Docker-network setup above.
+- **Not sure of the value?** Start Callis, attempt a login through the proxy, and read `source_ip` from the audit log — that is exactly the address to put in `TRUSTED_PROXIES`. (Loopback `127.0.0.1`/`::1` is always trusted, so you only need this when the proxy is a separate host or container — the usual case.)
+
+A wildcard `*` or a catch-all network (`0.0.0.0/0`, `::/0`) is refused at startup, because trusting it would let any client spoof their source IP — forging audit-log entries and bypassing login rate limiting.
 
 **2. Point your reverse proxy at Callis port 8080:**
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ ssh my-internal-server
 | `MAX_KEYS_PER_USER` | No | `5` | Maximum SSH keys per user |
 | `AUTH_MODE` | No | `local` | Only `local` is implemented today; OIDC support is planned |
 | `HTTPS_ENABLED` | No | `false` | Enable HSTS and Secure cookie flag |
-| `TRUSTED_PROXIES` | No | `*` | Comma-separated proxy IPs/CIDRs allowed to set `X-Forwarded-*` headers (only used when `HTTPS_ENABLED=true`) |
+| `TRUSTED_PROXIES` | When `HTTPS_ENABLED=true` | `*` | Comma-separated proxy IPs/CIDRs allowed to set `X-Forwarded-*` headers. **Required when `HTTPS_ENABLED=true`** — a wildcard `*` or empty value is refused at startup because it lets any client spoof `X-Forwarded-For` (forged audit IPs, rate-limit bypass). Ignored in LAN/HTTP mode. |
 | `DEV_MODE` | No | `false` | Enable development mode features (verbose SQL logging) |
 | `LOG_LEVEL` | No | `info` | Logging level |
 | `TZ` | No | `UTC` | Timezone |

--- a/api/core.py
+++ b/api/core.py
@@ -311,7 +311,7 @@ def _get_session_idle_timeout_seconds() -> int:
     return get_settings().SESSION_IDLE_TIMEOUT
 
 
-def create_jwt(user_id: str) -> str:
+def create_jwt(user_id: str, session_epoch: int = 0) -> str:
     settings = get_settings()
     issued_at = datetime.now(timezone.utc)
     expires_at = issued_at + timedelta(seconds=_get_session_max_lifetime_seconds())
@@ -320,6 +320,11 @@ def create_jwt(user_id: str) -> str:
         "iat": int(issued_at.timestamp()),
         "exp": int(expires_at.timestamp()),
         "last_activity": issued_at.isoformat(),
+        # Session-revocation epoch: the SessionMiddleware rejects the token if
+        # this no longer matches the user's current session_epoch in the DB,
+        # so bumping the user's epoch (e.g. on logout) invalidates all their
+        # outstanding tokens server-side despite the stateless JWT design.
+        "epoch": int(session_epoch),
     }
     return jwt.encode(payload, settings.SECRET_KEY, algorithm=JWT_ALGORITHM)
 
@@ -425,6 +430,52 @@ def verify_totp(secret: str, code: str) -> bool:
         matched |= secrets.compare_digest(expected, normalized_code)
 
     return valid_format and matched
+
+
+# TOTP replay protection: remember the last consumed time-step per user so a
+# code observed in transit cannot be replayed within its ~90s validity window.
+# This is a process-local cache (single-worker is the default Callis topology);
+# in a multi-worker deployment each worker guards its own accepted codes, which
+# still narrows — but does not fully close — the replay window.
+_totp_last_step: dict[str, int] = {}
+_totp_replay_lock = threading.Lock()
+
+
+def totp_matching_step(secret: str, code: str) -> int | None:
+    """Return the absolute time-step index a valid TOTP code matches, else None.
+
+    Mirrors verify_totp's ±1 skew tolerance and constant-time comparison, but
+    returns the matched step index so callers can enforce single-use (replay
+    protection) by rejecting a step that was already consumed.
+    """
+    submitted = code.strip()
+    valid_format = submitted.isdigit() and len(submitted) == 6
+    normalized_code = submitted if valid_format else "000000"
+
+    totp = pyotp.TOTP(secret)
+    now = datetime.now(timezone.utc).timestamp()
+    base_step = int(now // totp.interval)
+    matched_step: int | None = None
+    for step_offset in (-1, 0, 1):
+        expected = totp.at(now + (step_offset * totp.interval))
+        if secrets.compare_digest(expected, normalized_code):
+            matched_step = base_step + step_offset
+
+    return matched_step if valid_format else None
+
+
+def totp_consume_step(user_id: str, step: int) -> bool:
+    """Record a consumed TOTP step for *user_id*.
+
+    Returns True if the step is newly consumed (accept), or False if a step at
+    or before it was already used for this user (replay — reject).
+    """
+    with _totp_replay_lock:
+        last = _totp_last_step.get(user_id)
+        if last is not None and step <= last:
+            return False
+        _totp_last_step[user_id] = step
+        return True
 
 
 def get_totp_uri(secret: str, username: str) -> str:

--- a/api/core.py
+++ b/api/core.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import pyotp
 import qrcode
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, or_, select, update
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
@@ -43,6 +43,7 @@ from models import (
     Host,
     RecoveryCode,
     Setting,
+    User,
     host_group_hosts,
     host_group_users,
     user_host_assignment,
@@ -442,15 +443,6 @@ def verify_totp(secret: str, code: str) -> bool:
     return valid_format and matched
 
 
-# TOTP replay protection: remember the last consumed time-step per user so a
-# code observed in transit cannot be replayed within its ~90s validity window.
-# This is a process-local cache (single-worker is the default Callis topology);
-# in a multi-worker deployment each worker guards its own accepted codes, which
-# still narrows — but does not fully close — the replay window.
-_totp_last_step: dict[str, int] = {}
-_totp_replay_lock = threading.Lock()
-
-
 def totp_matching_step(secret: str, code: str) -> int | None:
     """Return the absolute time-step index a valid TOTP code matches, else None.
 
@@ -474,18 +466,26 @@ def totp_matching_step(secret: str, code: str) -> int | None:
     return matched_step if valid_format else None
 
 
-def totp_consume_step(user_id: str, step: int) -> bool:
-    """Record a consumed TOTP step for *user_id*.
+async def consume_totp_step(db: AsyncSession, user_id: str, step: int) -> bool:
+    """Atomically claim a TOTP time-step for single-use (durable replay guard).
 
-    Returns True if the step is newly consumed (accept), or False if a step at
-    or before it was already used for this user (replay — reject).
+    Advances ``users.last_totp_step`` to *step* only if it is currently unset or
+    below *step*, in a single UPDATE. Returns True if this call won the claim
+    (accept), or False if the step was already consumed (replay — reject).
+
+    Because the guard lives in the row, single-use holds across process
+    restarts and multiple API workers: concurrent claims of the same step
+    serialize on the row, and only the first UPDATE matches the WHERE clause.
     """
-    with _totp_replay_lock:
-        last = _totp_last_step.get(user_id)
-        if last is not None and step <= last:
-            return False
-        _totp_last_step[user_id] = step
-        return True
+    result = await db.execute(
+        update(User)
+        .where(
+            User.id == user_id,
+            or_(User.last_totp_step.is_(None), User.last_totp_step < step),
+        )
+        .values(last_totp_step=step)
+    )
+    return result.rowcount == 1
 
 
 def get_totp_uri(secret: str, username: str) -> str:

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import logging
 import shlex
 from contextlib import asynccontextmanager
@@ -72,29 +73,43 @@ app.add_middleware(TOTPGuardMiddleware)
 app.add_middleware(SetupGuardMiddleware)
 app.add_middleware(SessionMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
-# The SvelteKit SSR server always fronts this app from loopback and forwards
-# the real client address in X-Forwarded-For, so loopback is always trusted.
-# When HTTPS_ENABLED=true the deployment sits behind an additional TLS reverse
-# proxy; TRUSTED_PROXIES must name that proxy's IP/CIDR(s) so only it can extend
-# the forwarding chain. Trusting "*" would let ANY client spoof X-Forwarded-For,
-# forging audit-log source IPs and bypassing the per-IP login rate limiter — so
-# we fail closed on a missing/wildcard allow-list rather than fall open.
-_settings = get_settings()
-_proxy_tokens = [h.strip() for h in _settings.TRUSTED_PROXIES.split(",") if h.strip()]
-if _settings.HTTPS_ENABLED:
-    if not _proxy_tokens or "*" in _proxy_tokens:
+def _resolve_trusted_hosts(settings) -> list[str]:
+    """Resolve the proxy allow-list for ProxyHeadersMiddleware.
+
+    The SvelteKit SSR server always fronts this app from loopback and forwards
+    the real client address in X-Forwarded-For, so loopback is always trusted.
+    When HTTPS_ENABLED=true the deployment sits behind an additional TLS reverse
+    proxy; TRUSTED_PROXIES must name that proxy's IP/CIDR(s) so only it can
+    extend the forwarding chain. Trusting "*" — or a catch-all network like
+    0.0.0.0/0 or ::/0 — would let ANY client spoof X-Forwarded-For, forging
+    audit-log source IPs and bypassing the per-IP login rate limiter, so we fail
+    closed on a missing/wildcard/catch-all allow-list rather than fall open.
+    """
+    loopback = ["127.0.0.1", "::1"]
+    if not settings.HTTPS_ENABLED:
+        # LAN/HTTP mode: only the loopback SSR server is a trusted hop.
+        return loopback
+
+    tokens = [h.strip() for h in settings.TRUSTED_PROXIES.split(",") if h.strip()]
+
+    def _is_catch_all(token: str) -> bool:
+        try:
+            return ipaddress.ip_network(token, strict=False).prefixlen == 0
+        except ValueError:
+            return False
+
+    if not tokens or "*" in tokens or any(_is_catch_all(t) for t in tokens):
         raise RuntimeError(
             'HTTPS_ENABLED=true requires TRUSTED_PROXIES to name your reverse '
             "proxy's IP address(es) or CIDR(s), comma-separated. Trusting \"*\" "
-            "lets any client spoof X-Forwarded-For, forging audit source IPs and "
-            "bypassing login rate limiting. Set TRUSTED_PROXIES to your proxy and "
-            "restart."
+            "or a catch-all network (0.0.0.0/0, ::/0) lets any client spoof "
+            "X-Forwarded-For, forging audit source IPs and bypassing login rate "
+            "limiting. Set TRUSTED_PROXIES to your proxy and restart."
         )
-    _trusted_hosts: str | list[str] = ["127.0.0.1", "::1"] + _proxy_tokens
-else:
-    # LAN/HTTP mode: only the loopback SSR server is a trusted forwarding hop.
-    _trusted_hosts = ["127.0.0.1", "::1"]
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_trusted_hosts)
+    return loopback + tokens
+
+
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_resolve_trusted_hosts(get_settings()))
 
 # Routers — the JSON API is versioned under /api/v1 and is the single source
 # of truth for every value the frontend renders.
@@ -220,7 +235,29 @@ async def _init_db():
     engine = get_engine()
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await _apply_light_migrations(conn)
     _initialized.add("db")
+
+
+async def _apply_light_migrations(conn) -> None:
+    """Add columns introduced after a table was first created.
+
+    Callis has no migration framework; create_all only creates missing tables,
+    never alters existing ones. This idempotently adds newer columns so an
+    upgrade over an existing database picks them up. Works on SQLite and
+    PostgreSQL.
+    """
+    from sqlalchemy import inspect as _sa_inspect
+
+    def _user_columns(sync_conn):
+        return {c["name"] for c in _sa_inspect(sync_conn).get_columns("users")}
+
+    existing = await conn.run_sync(_user_columns)
+    if "session_epoch" not in existing:
+        logger.info("Migrating: adding users.session_epoch column")
+        await conn.exec_driver_sql(
+            "ALTER TABLE users ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0"
+        )
 
 
 async def run_servers():

--- a/api/main.py
+++ b/api/main.py
@@ -75,22 +75,25 @@ app.add_middleware(SecurityHeadersMiddleware)
 # The SvelteKit SSR server always fronts this app from loopback and forwards
 # the real client address in X-Forwarded-For, so loopback is always trusted.
 # When HTTPS_ENABLED=true the deployment sits behind an additional TLS reverse
-# proxy; TRUSTED_PROXIES (default "*") can be narrowed to specific IPs/CIDRs so
-# only known proxies can extend the forwarding chain, protecting audit-log
-# source IPs from being spoofed by direct clients.
+# proxy; TRUSTED_PROXIES must name that proxy's IP/CIDR(s) so only it can extend
+# the forwarding chain. Trusting "*" would let ANY client spoof X-Forwarded-For,
+# forging audit-log source IPs and bypassing the per-IP login rate limiter — so
+# we fail closed on a missing/wildcard allow-list rather than fall open.
 _settings = get_settings()
-_raw = _settings.TRUSTED_PROXIES.strip()
-if _settings.HTTPS_ENABLED and _raw == "*":
-    logger.warning(
-        "HTTPS_ENABLED is set with TRUSTED_PROXIES=\"*\": forwarded headers from "
-        "any client are trusted. Narrow TRUSTED_PROXIES to your proxy's IP/CIDR "
-        "so audit-log source IPs and rate limiting cannot be spoofed."
-    )
-    _trusted_hosts: str | list[str] = "*"
+_proxy_tokens = [h.strip() for h in _settings.TRUSTED_PROXIES.split(",") if h.strip()]
+if _settings.HTTPS_ENABLED:
+    if not _proxy_tokens or "*" in _proxy_tokens:
+        raise RuntimeError(
+            'HTTPS_ENABLED=true requires TRUSTED_PROXIES to name your reverse '
+            "proxy's IP address(es) or CIDR(s), comma-separated. Trusting \"*\" "
+            "lets any client spoof X-Forwarded-For, forging audit source IPs and "
+            "bypassing login rate limiting. Set TRUSTED_PROXIES to your proxy and "
+            "restart."
+        )
+    _trusted_hosts: str | list[str] = ["127.0.0.1", "::1"] + _proxy_tokens
 else:
+    # LAN/HTTP mode: only the loopback SSR server is a trusted forwarding hop.
     _trusted_hosts = ["127.0.0.1", "::1"]
-    if _settings.HTTPS_ENABLED:
-        _trusted_hosts += [h.strip() for h in _raw.split(",") if h.strip()]
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_trusted_hosts)
 
 # Routers — the JSON API is versioned under /api/v1 and is the single source

--- a/api/main.py
+++ b/api/main.py
@@ -278,13 +278,23 @@ async def _init_db():
     _initialized.add("db")
 
 
-async def _apply_light_migrations(conn) -> None:
-    """Add columns introduced after a table was first created.
+# Columns added to `users` after the table's original schema. Each entry is the
+# column name plus the type/constraint clause for the ALTER. create_all() only
+# creates missing tables, never alters existing ones, so these bridge upgrades
+# over an existing database. Keep additive and backward-compatible.
+_USER_COLUMN_MIGRATIONS = (
+    ("session_epoch", "INTEGER NOT NULL DEFAULT 0"),
+    ("last_totp_step", "BIGINT"),
+)
 
-    Callis has no migration framework; create_all only creates missing tables,
-    never alters existing ones. This idempotently adds newer columns so an
-    upgrade over an existing database picks them up. Works on SQLite and
-    PostgreSQL.
+
+async def _apply_light_migrations(conn) -> None:
+    """Idempotently add newer `users` columns; safe under concurrent startup.
+
+    Callis has no migration framework. On PostgreSQL we use ADD COLUMN IF NOT
+    EXISTS so two API processes starting at once cannot duplicate-column-crash;
+    on SQLite (single-writer, single-container by default) the inspect guard is
+    sufficient since it has no IF NOT EXISTS for ADD COLUMN.
     """
     from sqlalchemy import inspect as _sa_inspect
 
@@ -292,11 +302,20 @@ async def _apply_light_migrations(conn) -> None:
         return {c["name"] for c in _sa_inspect(sync_conn).get_columns("users")}
 
     existing = await conn.run_sync(_user_columns)
-    if "session_epoch" not in existing:
-        logger.info("Migrating: adding users.session_epoch column")
-        await conn.exec_driver_sql(
-            "ALTER TABLE users ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0"
-        )
+    is_postgres = conn.dialect.name == "postgresql"
+
+    for column, type_clause in _USER_COLUMN_MIGRATIONS:
+        if column in existing:
+            continue
+        logger.info("Migrating: adding users.%s column", column)
+        if is_postgres:
+            await conn.exec_driver_sql(
+                f"ALTER TABLE users ADD COLUMN IF NOT EXISTS {column} {type_clause}"
+            )
+        else:
+            await conn.exec_driver_sql(
+                f"ALTER TABLE users ADD COLUMN {column} {type_clause}"
+            )
 
 
 async def run_servers():

--- a/api/middleware/session.py
+++ b/api/middleware/session.py
@@ -36,7 +36,12 @@ class SessionMiddleware(BaseHTTPMiddleware):
                             select(User).where(User.id == user_id)
                         )
                         user = result.scalar_one_or_none()
-                        if user and user.is_active:
+                        # Reject tokens whose embedded epoch no longer matches
+                        # the user's current session_epoch (bumped on logout),
+                        # giving stateless JWTs a server-side revocation path.
+                        token_epoch = payload.get("epoch")
+                        epoch_ok = token_epoch == user.session_epoch if user else False
+                        if user and user.is_active and epoch_ok:
                             request.state.user = user
             elif reason == "expired" and payload:
                 # A real session ended (idle timeout or max lifetime).

--- a/api/models.py
+++ b/api/models.py
@@ -126,6 +126,10 @@ class User(Base):
     # Bumped to invalidate all of this user's outstanding session JWTs (which
     # embed the epoch at issue time) — e.g. on logout. See core.create_jwt.
     session_epoch = Column(Integer, default=0, server_default="0", nullable=False)
+    # Highest TOTP time-step consumed at login. An atomic compare-and-set on
+    # this column enforces single-use of a TOTP code across workers and
+    # restarts (durable replay protection). See core.consume_totp_step.
+    last_totp_step = Column(BigInteger, nullable=True)
     created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
     last_login_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/api/models.py
+++ b/api/models.py
@@ -77,6 +77,9 @@ class User(Base):
     totp_enrolled = Column(Boolean, default=False, nullable=False)
     role = Column(Enum(UserRole), default=UserRole.readonly, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
+    # Bumped to invalidate all of this user's outstanding session JWTs (which
+    # embed the epoch at issue time) — e.g. on logout. See core.create_jwt.
+    session_epoch = Column(Integer, default=0, server_default="0", nullable=False)
     created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
     last_login_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -23,7 +23,7 @@ async def audit_log(
     date_from: str = Query(None),
     date_to: str = Query(None),
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_role("readonly")),
+    user: User = Depends(require_role("admin")),
 ) -> AuditPageOut:
     query = select(AuditLog).options(selectinload(AuditLog.actor))
 

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -14,9 +14,9 @@ from core import (
     get_settings,
     hash_password,
     issue_recovery_codes,
+    consume_totp_step,
     limiter,
     looks_like_recovery_code,
-    totp_consume_step,
     totp_matching_step,
     totp_qr_b64,
     unused_recovery_code_count,
@@ -101,7 +101,9 @@ async def login_submit(
         # Match the TOTP code (±1 step, constant-time), then enforce single use
         # so a code observed in transit cannot be replayed within its window.
         matched_step = totp_matching_step(secret, submitted_totp_code)
-        totp_accepted = matched_step is not None and totp_consume_step(user.id, matched_step)
+        totp_accepted = matched_step is not None and await consume_totp_step(
+            db, user.id, matched_step
+        )
 
         # A single-use recovery code may be entered in place of the TOTP code
         # (lost/replaced authenticator device). Only attempted when the input

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -13,6 +13,8 @@ from core import (
     get_settings,
     hash_password,
     limiter,
+    totp_consume_step,
+    totp_matching_step,
     totp_qr_b64,
     verify_password,
     verify_totp,
@@ -88,13 +90,21 @@ async def login_submit(
         await db.commit()
         raise error
 
-    # If TOTP enrolled, verify code (always run decrypt+verify for constant-time)
+    # If TOTP enrolled, verify code (always run decrypt+match for constant-time)
     if user.totp_enrolled:
         secret = decrypt_totp_secret(user.totp_secret)
         submitted_totp_code = (body.totp_code or "").strip()
-        # verify_totp already handles invalid/empty formats in constant-time
-        if not verify_totp(secret, submitted_totp_code):
-            totp_failure_reason = "totp_missing" if not submitted_totp_code else "totp_invalid"
+        # Match the code (±1 step, constant-time), then enforce single use so a
+        # code observed in transit cannot be replayed within its validity window.
+        matched_step = totp_matching_step(secret, submitted_totp_code)
+        accepted = matched_step is not None and totp_consume_step(user.id, matched_step)
+        if not accepted:
+            if not submitted_totp_code:
+                totp_failure_reason = "totp_missing"
+            elif matched_step is not None:
+                totp_failure_reason = "totp_replay"
+            else:
+                totp_failure_reason = "totp_invalid"
             await write_audit_log(
                 db,
                 actor_id=None,
@@ -118,7 +128,7 @@ async def login_submit(
         source_ip=request.client.host if request.client else None,
     )
 
-    token = create_jwt(user.id)
+    token = create_jwt(user.id, user.session_epoch)
     set_session_cookie(response, token)
     return SessionOut(user=user_out(user))
 
@@ -188,6 +198,14 @@ async def logout(
 ):
     user = getattr(request.state, "user", None)
     if user:
+        # Bump the user's session epoch so every outstanding JWT they hold
+        # (this device and any other) stops validating — a real server-side
+        # logout, not just a client-side cookie delete.
+        db_user = (
+            await db.execute(select(User).where(User.id == user.id))
+        ).scalar_one_or_none()
+        if db_user:
+            db_user.session_epoch = (db_user.session_epoch or 0) + 1
         await write_audit_log(
             db,
             actor_id=user.id,

--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import selectinload
 
 from core import get_db, get_settings, get_ssh_host
 from dependencies import require_totp_complete
-from models import AuditLog, Host, SSHKey, User
+from models import AuditLog, Host, SSHKey, User, UserRole
 from schemas import DashboardOut, audit_entry_out
 
 router = APIRouter()
@@ -36,14 +36,18 @@ async def dashboard(
     )
     user_key_count = key_count_result.scalar()
 
-    # Recent audit (last 10)
-    audit_result = await db.execute(
-        select(AuditLog)
-        .options(selectinload(AuditLog.actor))
-        .order_by(AuditLog.timestamp.desc())
-        .limit(10)
-    )
-    recent_audit = audit_result.scalars().all()
+    # Recent audit (last 10) — admin-only, matching the audit log's access
+    # level. Non-admins get an empty feed (the dashboard hides the section).
+    if user.role == UserRole.admin:
+        audit_result = await db.execute(
+            select(AuditLog)
+            .options(selectinload(AuditLog.actor))
+            .order_by(AuditLog.timestamp.desc())
+            .limit(10)
+        )
+        recent_audit = audit_result.scalars().all()
+    else:
+        recent_audit = []
 
     return DashboardOut(
         active_users=active_users,

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from core import get_db, write_audit_log
-from dependencies import require_role, require_totp_complete
+from dependencies import require_role
 from models import AuditAction, Host, HostGroup, User
 from schemas import CreateGroupIn, GroupOut, group_out
 
@@ -42,8 +42,11 @@ async def _group_or_404(db: AsyncSession, group_id: str) -> HostGroup:
 @router.get("")
 async def group_list(
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_totp_complete),
+    user: User = Depends(require_role("admin")),
 ) -> list[GroupOut]:
+    # Admin-only: group_out exposes every group's hosts and member usernames —
+    # the same access map that must not leak to low-privilege users. Non-admins
+    # get their effective host access from GET /hosts, which is already scoped.
     result = await db.execute(
         select(HostGroup)
         .options(selectinload(HostGroup.hosts), selectinload(HostGroup.users))

--- a/api/routers/hosts.py
+++ b/api/routers/hosts.py
@@ -6,9 +6,15 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from core import get_db, get_server_deploy_public_key, slugify, write_audit_log
+from core import (
+    get_db,
+    get_effective_hosts,
+    get_server_deploy_public_key,
+    slugify,
+    write_audit_log,
+)
 from dependencies import require_role, require_totp_complete
-from models import AuditAction, Host, User, UserRole, user_host_assignment
+from models import AuditAction, Host, User, UserRole
 from schemas import CreateHostIn, DeployKeyOut, HostOut, host_out
 
 # Hostnames/IPv4 only; IPv6 literals (with colons) not yet supported
@@ -49,21 +55,24 @@ async def host_list(
         )
         return [host_out(h) for h in result.scalars().all()]
 
-    result = await db.execute(
-        select(Host)
-        .options(selectinload(Host.assigned_users))
-        .join(user_host_assignment)
-        .where(
-            user_host_assignment.c.user_id == user.id,
-            Host.is_active == True,
-        )
-        .order_by(Host.created_at.desc())
-    )
-    # Strip the assignment map — a non-admin must not learn who else can reach
-    # a host, only that they themselves can.
+    # Effective access = direct assignments ∪ host-group memberships (the same
+    # source of truth the SSH internal API uses), so a user assigned only via a
+    # group still sees their hosts. Build HostOut without the assignment map — a
+    # non-admin must not learn who else can reach a host, only that they can.
+    effective_hosts = await get_effective_hosts(db, user.id)
     return [
-        host_out(h).model_copy(update={"assigned_users": []})
-        for h in result.scalars().all()
+        HostOut(
+            id=h.id,
+            label=h.label,
+            alias=slugify(h.label),
+            hostname=h.hostname,
+            port=h.port,
+            description=h.description,
+            is_active=h.is_active,
+            created_at=h.created_at,
+            assigned_users=[],
+        )
+        for h in effective_hosts
     ]
 
 

--- a/api/routers/hosts.py
+++ b/api/routers/hosts.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from core import get_db, get_server_deploy_public_key, slugify, write_audit_log
 from dependencies import require_role, require_totp_complete
-from models import AuditAction, Host, User
+from models import AuditAction, Host, User, UserRole, user_host_assignment
 from schemas import CreateHostIn, DeployKeyOut, HostOut, host_out
 
 # Hostnames/IPv4 only; IPv6 literals (with colons) not yet supported
@@ -36,10 +36,35 @@ async def host_list(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_totp_complete),
 ) -> list[HostOut]:
+    # Admins manage the whole fleet and need the full inventory plus the
+    # user->host assignment map. Non-admins are shown only the hosts they can
+    # actually reach, with other users' assignments stripped — the internal SSH
+    # endpoint already filters this way; the web view must not leak the entire
+    # network topology and access map to a low-privilege account.
+    if user.role == UserRole.admin:
+        result = await db.execute(
+            select(Host)
+            .options(selectinload(Host.assigned_users))
+            .order_by(Host.created_at.desc())
+        )
+        return [host_out(h) for h in result.scalars().all()]
+
     result = await db.execute(
-        select(Host).options(selectinload(Host.assigned_users)).order_by(Host.created_at.desc())
+        select(Host)
+        .options(selectinload(Host.assigned_users))
+        .join(user_host_assignment)
+        .where(
+            user_host_assignment.c.user_id == user.id,
+            Host.is_active == True,
+        )
+        .order_by(Host.created_at.desc())
     )
-    return [host_out(h) for h in result.scalars().all()]
+    # Strip the assignment map — a non-admin must not learn who else can reach
+    # a host, only that they themselves can.
+    return [
+        host_out(h).model_copy(update={"assigned_users": []})
+        for h in result.scalars().all()
+    ]
 
 
 @router.get("/deploy-key")

--- a/api/routers/setup.py
+++ b/api/routers/setup.py
@@ -159,7 +159,7 @@ async def setup_submit(
                 raise HTTPException(status_code=400, detail=f"Username '{username}' is already taken.")
 
     # Set session cookie so TOTP step is authenticated
-    token = create_jwt(admin.id)
+    token = create_jwt(admin.id, admin.session_epoch)
     set_session_cookie(response, token)
     return SessionOut(user=user_out(admin))
 

--- a/api/tests/test_api_v1.py
+++ b/api/tests/test_api_v1.py
@@ -339,6 +339,99 @@ async def test_rbac_and_totp_guard(client):
 
 
 @pytest.mark.asyncio
+async def test_host_list_scoped_and_audit_admin_only(client):
+    await complete_setup(client)
+
+    # Admin creates two hosts, a readonly user, and assigns the user to one host.
+    h1 = (await client.post("/api/v1/hosts", json={"label": "Alpha", "hostname": "10.0.0.1"})).json()
+    (await client.post("/api/v1/hosts", json={"label": "Beta", "hostname": "10.0.0.2"})).json()
+    carol_id = (
+        await client.post(
+            "/api/v1/users",
+            json={"username": "carol", "password": USER_PASSWORD, "role": "readonly"},
+        )
+    ).json()["id"]
+    assert (await client.post(f"/api/v1/hosts/{h1['id']}/assign/{carol_id}")).status_code == 200
+
+    carol = AsyncClient(transport=ASGITransport(app=main.app), base_url="http://testserver")
+    async with carol:
+        assert (
+            await carol.post(
+                "/api/v1/auth/login",
+                json={"username": "carol", "password": USER_PASSWORD, "totp_code": ""},
+            )
+        ).status_code == 200
+        secret = (await carol.get("/api/v1/auth/totp/setup")).json()["secret"]
+        assert (
+            await carol.post(
+                "/api/v1/auth/totp/verify", json={"totp_code": pyotp.TOTP(secret).now()}
+            )
+        ).status_code == 200
+
+        # Finding 1: a non-admin sees ONLY assigned hosts, with no assignment map.
+        hosts = (await carol.get("/api/v1/hosts")).json()
+        assert [h["alias"] for h in hosts] == ["alpha"]
+        assert hosts[0]["assigned_users"] == []
+
+        # Admin still sees the full inventory including the assignment map.
+        admin_hosts = (await client.get("/api/v1/hosts")).json()
+        assert {h["alias"] for h in admin_hosts} == {"alpha", "beta"}
+        alpha = next(h for h in admin_hosts if h["alias"] == "alpha")
+        assert [u["username"] for u in alpha["assigned_users"]] == ["carol"]
+
+        # Finding 2: the audit log is admin-only.
+        assert (await carol.get("/api/v1/audit")).status_code == 403
+        assert (await client.get("/api/v1/audit")).status_code == 200
+
+        # Finding 2: the dashboard hides recent activity from non-admins.
+        assert (await carol.get("/api/v1/dashboard")).json()["recent_audit"] == []
+        assert len((await client.get("/api/v1/dashboard")).json()["recent_audit"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_session_revoked_server_side_on_logout(client):
+    await complete_setup(client)
+
+    # Capture the live session token, then log out (which bumps session_epoch).
+    old_cookie = client.cookies.get("callis_session")
+    assert old_cookie
+    assert (await client.post("/api/v1/auth/logout")).status_code == 204
+
+    # Finding 4: replaying the pre-logout token is rejected server-side, not
+    # merely cleared client-side. Restore the captured token onto the client
+    # (logout deleted it) and confirm the API still refuses it.
+    client.cookies.set("callis_session", old_cookie)
+    r = await client.get("/api/v1/auth/me")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_totp_code_cannot_be_replayed(client):
+    secret = await complete_setup(client)
+    await client.post("/api/v1/auth/logout")
+
+    code = pyotp.TOTP(secret).now()
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": code},
+    )
+    assert r.status_code == 200
+
+    # Finding 5: the same code is refused on a second login even though it is
+    # still within its validity window.
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin", "password": ADMIN_PASSWORD, "totp_code": code},
+    )
+    assert r.status_code == 401
+    r = await client.get("/api/v1/audit", params={"action": "totp_failure"})
+    assert any(
+        e["detail"] and e["detail"].get("reason") == "totp_replay"
+        for e in r.json()["entries"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_unauthenticated_requests_rejected(client):
     await complete_setup(client)
     fresh = AsyncClient(transport=ASGITransport(app=main.app), base_url="http://testserver")

--- a/api/tests/test_api_v1.py
+++ b/api/tests/test_api_v1.py
@@ -575,6 +575,50 @@ async def test_host_groups_flow(client):
 
 
 @pytest.mark.asyncio
+async def test_group_hosts_visible_to_member_but_groups_admin_only(client):
+    await complete_setup(client)
+
+    # Admin builds a group containing a host and adds a readonly user to it.
+    host_id = (
+        await client.post("/api/v1/hosts", json={"label": "Grp Web", "hostname": "grp.internal"})
+    ).json()["id"]
+    group_id = (await client.post("/api/v1/groups", json={"name": "team"})).json()["id"]
+    assert (await client.post(f"/api/v1/groups/{group_id}/hosts/{host_id}")).status_code == 200
+    dave_id = (
+        await client.post(
+            "/api/v1/users",
+            json={"username": "dave", "password": USER_PASSWORD, "role": "readonly"},
+        )
+    ).json()["id"]
+    assert (await client.post(f"/api/v1/groups/{group_id}/users/{dave_id}")).status_code == 200
+
+    dave = AsyncClient(transport=ASGITransport(app=main.app), base_url="http://testserver")
+    async with dave:
+        assert (
+            await dave.post(
+                "/api/v1/auth/login",
+                json={"username": "dave", "password": USER_PASSWORD, "totp_code": ""},
+            )
+        ).status_code == 200
+        secret = (await dave.get("/api/v1/auth/totp/setup")).json()["secret"]
+        assert (
+            await dave.post(
+                "/api/v1/auth/totp/verify", json={"totp_code": pyotp.TOTP(secret).now()}
+            )
+        ).status_code == 200
+
+        # P1: a group-only assignment still surfaces the host in the scoped
+        # list, with the assignment map stripped.
+        hosts = (await dave.get("/api/v1/hosts")).json()
+        assert [h["alias"] for h in hosts] == ["grp-web"]
+        assert hosts[0]["assigned_users"] == []
+
+        # P1: the groups endpoint (host + member map) is admin-only.
+        assert (await dave.get("/api/v1/groups")).status_code == 403
+        assert (await client.get("/api/v1/groups")).status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_sessions_endpoints(client):
     from models import SshSession
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,9 +42,14 @@ Create `.env` with proxy settings:
 ```env
 BASE_URL=https://callis.example.com
 HTTPS_ENABLED=true
-# Required with HTTPS_ENABLED — set to your reverse proxy's IP/CIDR so only it
-# can supply X-Forwarded-For. A wildcard "*" is refused at startup.
-TRUSTED_PROXIES=127.0.0.1
+# Required with HTTPS_ENABLED. Set it to the address Callis SEES your proxy
+# connect from (NOT the proxy's public address, and usually NOT 127.0.0.1).
+# Recommended: run the proxy on the same Docker network with the web port
+# unpublished, and set this to that network's subnet (docker network inspect).
+# Unsure? Attempt a login through the proxy and read source_ip from the audit
+# log — that is the value to use. A wildcard "*" or catch-all (0.0.0.0/0, ::/0)
+# is refused at startup. See the README "Choosing TRUSTED_PROXIES" section.
+TRUSTED_PROXIES=172.18.0.0/16
 ```
 
 Start:
@@ -79,7 +84,7 @@ The planned design: `AUTH_MODE=oidc` plus `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OI
 | `OIDC_CLIENT_ID` | If OIDC | — | OIDC client ID |
 | `OIDC_CLIENT_SECRET` | If OIDC | — | OIDC client secret |
 | `HTTPS_ENABLED` | No | `false` | Enable HSTS and Secure cookie flag |
-| `TRUSTED_PROXIES` | When `HTTPS_ENABLED=true` | `*` | Comma-separated reverse-proxy IPs/CIDRs allowed to set `X-Forwarded-*`. Required when `HTTPS_ENABLED=true` — a wildcard `*` or empty value is refused at startup (it would let any client spoof `X-Forwarded-For`, forging audit source IPs and bypassing rate limiting). Ignored in LAN/HTTP mode (only loopback is trusted). |
+| `TRUSTED_PROXIES` | When `HTTPS_ENABLED=true` | `*` | Comma-separated IPs/CIDRs Callis **observes the proxy connect from** (for Docker, the proxy's network subnet or bridge gateway — usually not `127.0.0.1`); only that peer may set `X-Forwarded-*`. Required when `HTTPS_ENABLED=true` — `*`, empty, or a catch-all (`0.0.0.0/0`, `::/0`) is refused at startup (it would let any client spoof `X-Forwarded-For`, forging audit source IPs and bypassing rate limiting). Ignored in LAN/HTTP mode (only loopback is trusted). See the README "Choosing TRUSTED_PROXIES" section. |
 | `DEV_MODE` | No | `false` | Enable verbose SQL logging |
 | `LOG_LEVEL` | No | `info` | Logging level (debug, info, warning, error) |
 | `TZ` | No | `UTC` | Timezone for log timestamps |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,6 +42,9 @@ Create `.env` with proxy settings:
 ```env
 BASE_URL=https://callis.example.com
 HTTPS_ENABLED=true
+# Required with HTTPS_ENABLED — set to your reverse proxy's IP/CIDR so only it
+# can supply X-Forwarded-For. A wildcard "*" is refused at startup.
+TRUSTED_PROXIES=127.0.0.1
 ```
 
 Start:
@@ -76,6 +79,7 @@ The planned design: `AUTH_MODE=oidc` plus `OIDC_ISSUER` / `OIDC_CLIENT_ID` / `OI
 | `OIDC_CLIENT_ID` | If OIDC | — | OIDC client ID |
 | `OIDC_CLIENT_SECRET` | If OIDC | — | OIDC client secret |
 | `HTTPS_ENABLED` | No | `false` | Enable HSTS and Secure cookie flag |
+| `TRUSTED_PROXIES` | When `HTTPS_ENABLED=true` | `*` | Comma-separated reverse-proxy IPs/CIDRs allowed to set `X-Forwarded-*`. Required when `HTTPS_ENABLED=true` — a wildcard `*` or empty value is refused at startup (it would let any client spoof `X-Forwarded-For`, forging audit source IPs and bypassing rate limiting). Ignored in LAN/HTTP mode (only loopback is trusted). |
 | `DEV_MODE` | No | `false` | Enable verbose SQL logging |
 | `LOG_LEVEL` | No | `info` | Logging level (debug, info, warning, error) |
 | `TZ` | No | `UTC` | Timezone for log timestamps |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -28,15 +28,21 @@ These are non-negotiable rules enforced in code, not guidelines.
 - TOTP is mandatory. No user may access protected pages until TOTP enrollment is complete. This is enforced via `require_totp_complete` route dependencies and by `TOTPGuardMiddleware`, which redirects authenticated users without enrolled TOTP to `/totp/setup`.
 - After TOTP setup, every login requires password AND TOTP code. There is no "remember this device."
 - Failed login attempts (wrong password or wrong TOTP) return the same error message and take the same time to respond (constant-time comparison). This prevents both user enumeration and timing attacks.
+- A TOTP code is single-use per login: once a code is accepted, the same code (and any earlier time-step) is rejected for that user, so a code observed in transit cannot be replayed within its validity window.
 - Sessions expire after idle timeout (default: 30 minutes) and have an absolute maximum lifetime (default: 8 hours).
+- Sessions can be revoked server-side. Each session JWT embeds the user's `session_epoch`; logging out increments it, so every outstanding token for that user stops validating — logout is a real server-side revocation, not just a client-side cookie delete.
 
 ### 1.4 Authorization
 
 - Role hierarchy: `admin` > `operator` > `readonly`.
 - Role checks use FastAPI dependencies (`require_role("admin")`), applied at the route level — never scattered inline.
 - Users cannot elevate their own role.
-- `readonly` users can only view the audit log.
-- `operator` users can manage hosts assigned to them.
+- The audit log (and the dashboard's recent-activity feed) is **admin-only**.
+- Non-admins see only the hosts assigned to them in the web UI, with other
+  users' assignments stripped — the host inventory and access map are not
+  disclosed to low-privilege accounts. Admins see the full inventory and the
+  assignment map. (The sshd-facing internal API has always filtered by
+  assignment; the web view now matches.)
 - `admin` users have full access.
 - A user can never view another user's key text, only fingerprints and metadata.
 

--- a/frontend/src/lib/server/api.ts
+++ b/frontend/src/lib/server/api.ts
@@ -23,20 +23,102 @@ export interface ApiError {
  *  server (same switch the API uses for its TRUSTED_PROXIES handling). */
 const behindTrustedProxy = () => (env.HTTPS_ENABLED ?? '').toLowerCase() === 'true';
 
-function clientAddressChain(event: RequestEvent): string {
+/** Parse an IPv4/IPv6 address to a big-integer value + width, or null. */
+function parseIp(raw: string): { value: bigint; bits: number } | null {
+	let ip = raw.trim();
+	const zone = ip.indexOf('%');
+	if (zone !== -1) ip = ip.slice(0, zone);
+	if (!ip) return null;
+	if (!ip.includes(':')) {
+		const parts = ip.split('.');
+		if (parts.length !== 4) return null;
+		let value = 0n;
+		for (const p of parts) {
+			if (!/^\d{1,3}$/.test(p)) return null;
+			const n = Number(p);
+			if (n > 255) return null;
+			value = (value << 8n) | BigInt(n);
+		}
+		return { value, bits: 32 };
+	}
+	// IPv6 — fold any trailing embedded IPv4 (e.g. ::ffff:1.2.3.4) into hextets.
+	if (ip.includes('.')) {
+		const idx = ip.lastIndexOf(':');
+		if (idx === -1) return null;
+		const v4 = parseIp(ip.slice(idx + 1));
+		if (!v4 || v4.bits !== 32) return null;
+		const hi = ((v4.value >> 16n) & 0xffffn).toString(16);
+		const lo = (v4.value & 0xffffn).toString(16);
+		ip = ip.slice(0, idx + 1) + hi + ':' + lo;
+	}
+	const halves = ip.split('::');
+	if (halves.length > 2) return null;
+	const toGroups = (s: string) => (s === '' ? [] : s.split(':'));
+	const head = toGroups(halves[0]);
+	const tail = halves.length === 2 ? toGroups(halves[1]) : null;
+	let groups: string[];
+	if (tail === null) {
+		groups = head;
+	} else {
+		const missing = 8 - head.length - tail.length;
+		if (missing < 0) return null;
+		groups = [...head, ...Array(missing).fill('0'), ...tail];
+	}
+	if (groups.length !== 8) return null;
+	let value = 0n;
+	for (const g of groups) {
+		if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+		value = (value << 16n) | BigInt(parseInt(g, 16));
+	}
+	return { value, bits: 128 };
+}
+
+/** True if `peer` falls within the IP or CIDR `token` (same address family). */
+function ipInToken(peer: string, token: string): boolean {
+	const slash = token.indexOf('/');
+	const net = parseIp(slash === -1 ? token : token.slice(0, slash));
+	const addr = parseIp(peer);
+	if (!net || !addr || net.bits !== addr.bits) return false;
+	const prefix = slash === -1 ? addr.bits : Number(token.slice(slash + 1));
+	if (!Number.isInteger(prefix) || prefix < 0 || prefix > addr.bits) return false;
+	if (prefix === 0) return true;
+	const shift = BigInt(addr.bits - prefix);
+	return addr.value >> shift === net.value >> shift;
+}
+
+/** Whether the direct peer that connected to the SSR is a declared trusted
+ *  proxy. Only then may we believe its X-Forwarded-* headers. A client that
+ *  reaches the web port directly (bypassing the reverse proxy) is NOT trusted,
+ *  so it cannot spoof X-Forwarded-For to forge audit IPs or dodge rate limits.
+ *  Mirrors the API's TRUSTED_PROXIES allow-list, plus loopback. */
+function proxyPeerTrusted(event: RequestEvent): boolean {
+	if (!behindTrustedProxy()) return false;
+	let peer = '';
+	try {
+		peer = event.getClientAddress();
+	} catch {
+		return false;
+	}
+	if (!peer) return false;
+	const tokens = (env.TRUSTED_PROXIES ?? '')
+		.split(',')
+		.map((t) => t.trim())
+		.filter((t) => t && t !== '*');
+	return ['127.0.0.1', '::1', ...tokens].some((t) => ipInToken(peer, t));
+}
+
+function clientAddressChain(event: RequestEvent, peerTrusted: boolean): string {
 	let addr = '';
 	try {
 		addr = event.getClientAddress();
 	} catch {
 		// Prerendering or unavailable socket — leave empty.
 	}
-	// Only propagate the browser-supplied X-Forwarded-For chain when a front
-	// proxy is explicitly declared; otherwise a direct client (including one
+	// Only propagate the browser-supplied X-Forwarded-For chain when the direct
+	// peer is a declared trusted proxy; otherwise a direct client (including one
 	// connecting over a loopback SSH tunnel, which the API trusts as a hop)
 	// could spoof its address to skew rate limiting and audit source IPs.
-	const incoming = behindTrustedProxy()
-		? event.request.headers.get('x-forwarded-for')
-		: null;
+	const incoming = peerTrusted ? event.request.headers.get('x-forwarded-for') : null;
 	return [incoming, addr].filter(Boolean).join(', ');
 }
 
@@ -50,13 +132,12 @@ export async function apiFetch(
 	};
 	const cookie = event.request.headers.get('cookie');
 	if (cookie) headers['cookie'] = cookie;
-	const xff = clientAddressChain(event);
+	const peerTrusted = proxyPeerTrusted(event);
+	const xff = clientAddressChain(event, peerTrusted);
 	if (xff) headers['x-forwarded-for'] = xff;
-	// Pass through the TLS proxy's protocol hint only when a front proxy is
-	// declared; a direct client's header is untrusted.
-	const proto = behindTrustedProxy()
-		? event.request.headers.get('x-forwarded-proto')
-		: null;
+	// Pass through the TLS proxy's protocol hint only when the direct peer is a
+	// declared trusted proxy; a direct client's header is untrusted.
+	const proto = peerTrusted ? event.request.headers.get('x-forwarded-proto') : null;
 	if (proto) headers['x-forwarded-proto'] = proto;
 
 	let body: string | undefined;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -29,8 +29,8 @@
 				{/if}
 				<li><a href="/users/{user.id}">My Profile</a></li>
 				<li><a href="/hosts">Hosts</a></li>
-				<li><a href="/audit">Audit Log</a></li>
 				{#if user.role === 'admin'}
+					<li><a href="/audit">Audit Log</a></li>
 					<li><a href="/settings">Settings</a></li>
 				{/if}
 			{/if}

--- a/frontend/src/routes/hosts/+page.server.ts
+++ b/frontend/src/routes/hosts/+page.server.ts
@@ -9,20 +9,23 @@ interface DeployKey {
 
 export const load: PageServerLoad = async (event) => {
 	const { user } = await event.parent();
-	const [hosts, groups] = await Promise.all([
-		apiJson<Host[]>(event, '/api/v1/hosts'),
-		apiJson<Group[]>(event, '/api/v1/groups')
-	]);
+	const hosts = await apiJson<Host[]>(event, '/api/v1/hosts');
 
-	// Admin-only extras: assignable users + the server deploy key. Fetched
-	// concurrently; non-admins never trigger these requests.
+	// Admin-only extras: host groups (their host/member map), assignable users,
+	// and the server deploy key. Fetched only for admins; non-admins never
+	// trigger these requests and the groups access map never leaves the server.
+	let groups: Group[] = [];
 	let allUsers: { id: string; username: string }[] = [];
 	let deployKey = '';
 	if (user?.role === 'admin') {
-		const [usersResponse, keyResponse] = await Promise.all([
+		const [groupsResponse, usersResponse, keyResponse] = await Promise.all([
+			apiFetch(event, '/api/v1/groups'),
 			apiFetch(event, '/api/v1/users'),
 			apiFetch(event, '/api/v1/hosts/deploy-key')
 		]);
+		if (groupsResponse.ok) {
+			groups = (await groupsResponse.json()) as Group[];
+		}
 		if (usersResponse.ok) {
 			const users = (await usersResponse.json()) as UserListItem[];
 			allUsers = users


### PR DESCRIPTION
## Summary

Addresses findings from an adversarial security review of Callis. Started as the `TRUSTED_PROXIES` fail-closed fix and expanded to the full set of review findings plus PR-review feedback.

## Findings addressed

**Finding 1 — Host inventory / access-map disclosure (broken access control).**
`GET /api/v1/hosts` returned every host (internal hostname, port, description) and the complete user→host assignment map to any authenticated user, including the lowest-privilege `readonly` role — leaking the internal network topology and who-can-reach-what. Non-admins now receive only the hosts assigned to them, with other users' assignments stripped; admins keep the full inventory and assignment map. This matches the sshd-facing internal endpoint, which already filtered by assignment.

**Finding 2 — Audit log exposure.**
The audit log was gated at `require_role("readonly")` — satisfied by every account — and the dashboard's recent-activity feed was shown to all users. Both exposed org-wide source IPs, usernames, and actions to low-privilege accounts. The audit log and the recent-activity feed are now **admin-only**, and the Audit Log nav link is admin-gated.

**Finding 3 — Spoofable reverse-proxy trust (audit-IP forgery + rate-limit bypass).**
- API side: when `HTTPS_ENABLED=true`, an explicit `TRUSTED_PROXIES` allow-list is now required; `*`, empty, **and catch-all networks (`0.0.0.0/0`, `::/0`)** are refused at startup instead of trusting all clients.
- SSR side (from PR review — the real trust boundary): the SvelteKit server previously forwarded any incoming `X-Forwarded-For` whenever `HTTPS_ENABLED`, so a client reaching the web port directly (bypassing the proxy) could still spoof it. The SSR now honors incoming `X-Forwarded-For`/`X-Forwarded-Proto` only when the **direct peer** is a declared trusted proxy (IP/CIDR match against `TRUSTED_PROXIES` + loopback).
- Docs: README Mode B now sets `TRUSTED_PROXIES` so the documented HTTPS deployment starts.

**Finding 4 — No server-side session revocation.**
Logout only cleared the client cookie; a captured JWT stayed valid until expiry. Added `User.session_epoch`, embedded in each JWT and verified by the session middleware. Logout increments it, invalidating every outstanding token for that user (a real server-side logout). Includes an idempotent startup migration that adds the column to existing databases (Callis has no migration framework).

**Finding 5 — TOTP replay.**
A valid code was accepted for its full ~90s window with no single-use check. Login now records the consumed time-step per user and rejects reuse of that or any earlier step (audited as `totp_replay`). Hard account lockout was **deliberately not added**: on a bastion it enables a targeted DoS against admin accounts, while per-IP rate limiting + mandatory TOTP + bcrypt already make online brute-force impractical.

## Tests

Added coverage for host-list scoping, admin-only audit + dashboard feed, server-side session revocation on logout, and TOTP replay rejection. Full backend suite: **35 passed**. Frontend `svelte-check`: **0 errors**. The IP/CIDR matcher was validated against IPv4/IPv6, CIDR, family-mismatch, embedded-IPv4, and catch-all cases. The light migration was verified against a legacy database missing the column.

## Upgrade notes

- Deployments running `HTTPS_ENABLED=true` with a wildcard/empty/catch-all `TRUSTED_PROXIES` must set it to their proxy's IP/CIDR on upgrade (intentional fail-closed).
- Existing logged-in users are logged out once on upgrade (their tokens predate the `session_epoch` claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvqReYse2WcXN4Vn8Qdj4C