### PR TITLE
Address post-merge review findings (recovery codes / sessions / groups)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Res
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import select, func, text
+from sqlalchemy.ext.asyncio import AsyncEngine
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from core import get_engine, get_runtime_setting, get_session_factory, get_settings, limiter, load_db_settings
@@ -221,7 +222,7 @@ async def generic_exception_handler(request: Request, exc: Exception):
 _initialized: set[str] = set()
 
 
-async def _sync_pg_audit_enum(engine) -> None:
+async def _sync_pg_audit_enum(engine: AsyncEngine) -> None:
     """PostgreSQL only: add any missing AuditAction labels to the native enum.
 
     Base.metadata.create_all() creates missing tables but never alters an

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -67,7 +68,13 @@ async def create_group(
 
     group = HostGroup(name=name, description=body.description)
     db.add(group)
-    await db.flush()
+    try:
+        # The pre-check above narrows the window, but HostGroup.name is unique
+        # and a concurrent insert can still lose the race here.
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail="A group with this name already exists")
 
     await write_audit_log(
         db,

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -74,7 +74,9 @@ async def create_group(
         # session back when the HTTPException propagates out.
         await db.flush()
     except IntegrityError:
-        raise HTTPException(status_code=400, detail="A group with this name already exists")
+        raise HTTPException(
+            status_code=400, detail="A group with this name already exists"
+        ) from None
 
     await write_audit_log(
         db,

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -70,10 +70,10 @@ async def create_group(
     db.add(group)
     try:
         # The pre-check above narrows the window, but HostGroup.name is unique
-        # and a concurrent insert can still lose the race here.
+        # and a concurrent insert can still lose the race here. get_db rolls the
+        # session back when the HTTPException propagates out.
         await db.flush()
     except IntegrityError:
-        await db.rollback()
         raise HTTPException(status_code=400, detail="A group with this name already exists")
 
     await write_audit_log(

--- a/api/session_tracker.py
+++ b/api/session_tracker.py
@@ -97,7 +97,7 @@ async def _handle_accept(db, event: dict) -> None:
         return
 
     result = await db.execute(
-        select(User).where(User.username == event["username"], User.is_active == True)  # noqa: E712
+        select(User).where(User.username == event["username"], User.is_active.is_(True))
     )
     user = result.scalar_one_or_none()
 

--- a/api/session_tracker.py
+++ b/api/session_tracker.py
@@ -97,7 +97,7 @@ async def _handle_accept(db, event: dict) -> None:
         return
 
     result = await db.execute(
-        select(User).where(User.username == event["username"], User.is_active == True)
+        select(User).where(User.username == event["username"], User.is_active == True)  # noqa: E712
     )
     user = result.scalar_one_or_none()
 

--- a/api/tests/test_api_v1.py
+++ b/api/tests/test_api_v1.py
@@ -321,6 +321,12 @@ async def test_rbac_and_totp_guard(client):
         r = await bob.get("/api/v1/hosts/deploy-key")
         assert r.status_code == 403
 
+        # Group management and session control are admin-only
+        r = await bob.post("/api/v1/groups", json={"name": "prod"})
+        assert r.status_code == 403
+        r = await bob.post("/api/v1/sessions/nonexistent/terminate")
+        assert r.status_code == 403
+
         # Hosts list is visible to any enrolled user
         r = await bob.get("/api/v1/hosts")
         assert r.status_code == 200
@@ -343,9 +349,20 @@ async def test_unauthenticated_requests_rejected(client):
     await complete_setup(client)
     fresh = AsyncClient(transport=ASGITransport(app=main.app), base_url="http://testserver")
     async with fresh:
-        for path in ("/api/v1/dashboard", "/api/v1/users", "/api/v1/hosts", "/api/v1/audit", "/api/v1/settings"):
+        for path in (
+            "/api/v1/dashboard",
+            "/api/v1/users",
+            "/api/v1/hosts",
+            "/api/v1/audit",
+            "/api/v1/settings",
+            "/api/v1/groups",
+            "/api/v1/sessions",
+        ):
             r = await fresh.get(path)
             assert r.status_code == 401, path
+        # Mutating group/session routes reject anonymous callers too
+        assert (await fresh.post("/api/v1/groups", json={"name": "x"})).status_code == 401
+        assert (await fresh.post("/api/v1/sessions/x/terminate")).status_code == 401
         # Meta and health stay public
         assert (await fresh.get("/api/v1/meta")).status_code == 200
         assert (await fresh.get("/health")).status_code == 200

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,7 +94,8 @@ The application is split across two listeners:
 The api process also runs a **session tracker** (started in the FastAPI lifespan): it tails the sshd log (`/var/log/callis/auth.log`, the same file the fail2ban sidecar reads) and records accepted connections and disconnects as `SshSession` rows with `session_opened`/`session_closed` audit entries. The tracker persists its read position so an API-only restart resumes where it stopped, and the startup sweep only closes records whose connection is no longer established. In the unified container, admins can terminate a session from the web UI — the tracker locates the per-connection sshd child via `/proc/net/tcp{,6}` socket-inode matching and signals it (api and sshd share a PID namespace).
 
 **Directory layout:**
-```
+
+```text
 api/
 ├── Dockerfile               # Standalone API image (for split deploys)
 ├── pyproject.toml


### PR DESCRIPTION
Follow-up to the merged #37, addressing the actionable CodeRabbit review comments that landed after the merge. Each change is small and scoped to the specific finding.

## Changes

- **`api/main.py`** — Type-hint `_sync_pg_audit_enum(engine: AsyncEngine)` and import `AsyncEngine` from `sqlalchemy.ext.asyncio`, matching the return type of `core.get_engine()`. (The `contextlib.suppress` finding was already resolved in the merged branch.)
- **`api/routers/groups.py`** — Catch `IntegrityError` on `create_group`'s `flush()` so the unique-name race that slips past the pre-check returns the same `400` instead of falling through to the global 500 handler.
- **`api/session_tracker.py`** — Suppress Ruff `E712` on the `is_active == True` predicate with `# noqa: E712`, consistent with the existing convention in `core.py`.
- **`api/tests/test_api_v1.py`** — Add unauthenticated (`401`) and non-admin (`403`) coverage for the `/api/v1/groups` and `/api/v1/sessions` routes, including the terminate endpoint, alongside the existing happy-path/404 tests.
- **`docs/ARCHITECTURE.md`** — Add a blank line before the directory-layout fence and a `text` language tag (markdownlint MD031/MD040).

## Testing

- `uv run pytest -q` — 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y23LZbxMCY2EFJNwDvyGU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y23LZbxMCY2EFJNwDvyGU7)_